### PR TITLE
Enable limit_latest_versions to be configured from configuration

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -9,3 +9,4 @@ runtime_environments:
       version: "7"
     python_version: "3.6"
     recommendation_type: latest
+    limit_latest_versions: null

--- a/examples/lockdown/.thoth.yaml
+++ b/examples/lockdown/.thoth.yaml
@@ -9,6 +9,7 @@ requirements_format: pipenv
 runtime_environments:
   - name: "fedora:29"
     recommendation_type: latest
+    limit_latest_versions: null
     operating_system:
       name: fedora
       version: "29"

--- a/examples/runtime-environment/.thoth.yaml
+++ b/examples/runtime-environment/.thoth.yaml
@@ -22,3 +22,4 @@ runtime_environments:
     cuda_version: null
     # Recommendation type - one of testing, stable, latest:
     recommendation_type: stable
+    limit_latest_versions: null

--- a/examples/scoring/.thoth.yaml
+++ b/examples/scoring/.thoth.yaml
@@ -14,3 +14,4 @@ runtime_environments:
       name: fedora
       version: "29"
     recommendation_type: stable
+    limit_latest_versions: null

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -128,7 +128,8 @@ def _print_header(header: str) -> None:
     click.echo(padding * " " + "=" * len(header) + "  \n")
 
 
-def _write_configuration(advised_configuration: dict, recommendation_type: str = None) -> None:
+def _write_configuration(advised_configuration: dict, recommendation_type: str = None,
+                         limit_latest_versions: int = None) -> None:
     if not advised_configuration:
         _LOGGER.debug("No advises on configuration, nothing to adjust")
         return
@@ -152,6 +153,8 @@ def _write_configuration(advised_configuration: dict, recommendation_type: str =
             runtime_environment_entry = advised_configuration
             if recommendation_type:
                 runtime_environment_entry["recommendation_type"] = recommendation_type
+            if limit_latest_versions:
+                runtime_environment_entry["limit_latest_versions"] = limit_latest_versions
             break
     else:
         _LOGGER.error(
@@ -351,7 +354,7 @@ def advise(
             pipfile = result["report"][0][1]["requirements"]
             pipfile_lock = result["report"][0][1]["requirements_locked"]
 
-            _write_configuration(result["advised_configuration"], recommendation_type)
+            _write_configuration(result["advised_configuration"], recommendation_type, limit_latest_versions)
             _write_pipfiles(pipfile, pipfile_lock)
         else:
             click.echo(json.dumps(result, indent=2))

--- a/thamos/data/defaultThoth.yaml
+++ b/thamos/data/defaultThoth.yaml
@@ -27,6 +27,8 @@ runtime_environments:
     cuda_version: {cuda_version}
     # Recommendation type - one of testing, stable, latest:
     recommendation_type: stable
+    # Limit Latest Versions
+    limit_latest_versions: null
 
 #
 # Configuration of bots:

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -149,6 +149,9 @@ def advise(
         )
 
     # We use the explicit one if provided at the end.
+    limit_latest_versions_explicit = limit_latest_versions
+    limit_latest_versions = thoth_config.content.get("limit_latest_versions")
+
     recommendation_type_explicit = recommendation_type
     recommendation_type = thoth_config.content.get("recommendation_type") or "stable"
     runtime_environment = runtime_environment or thoth_config.get_runtime_environment(
@@ -161,6 +164,8 @@ def advise(
         # Override recommendation type specified explicitly in the runtime environment entry.
         if "recommendation_type" in runtime_environment:
             recommendation_type = runtime_environment.pop("recommendation_type")
+        if "limit_latest_versions" in runtime_environment:
+            limit_latest_versions = runtime_environment.pop("limit_latest_versions")
 
         runtime_environment = RuntimeEnvironment(**runtime_environment)
 
@@ -186,6 +191,7 @@ def advise(
     if count is not None:
         parameters["count"] = count
 
+    limit_latest_versions = limit_latest_versions_explicit or limit_latest_versions
     if limit_latest_versions is not None:
         parameters["limit_latest_versions"] = limit_latest_versions
 


### PR DESCRIPTION
Updated the configuration of limit_latest_versions from the configuration file (.thoth.yaml).
Fixes: #111