### PR TITLE
WIP: Provide a way to note last analysis id into a temporary file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,12 @@ installation instructions bellow to setup Thoth/Thamos for your repository:
   $ thamos config
   # Ask Thoth for software stack recommendations:
   $ thamos advise
+  # Retrieve logs of the last analysis:
+  $ thamos log
+
+
+As Thamos notes analysis ids for better UX of ``thamos log``, it's recommended to
+add ``.thoth_last_analysis_id`` file to ``.gitignore``.
 
 
 Adjusting configuration based on environment variables

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -448,10 +448,19 @@ def provenance_check(
 
 
 @cli.command("log")
-@click.argument("analysis_id", type=str)
-def log(analysis_id: str):
-    """Get log of running or finished analysis."""
-    click.echo(get_log(analysis_id))
+@click.argument("analysis_id", type=str, required=False)
+def log(analysis_id: str = None):
+    """Get log of running or finished analysis.
+
+    If ANALYSIS_ID is not provided, there will be used last analysis id, if noted by Thamos.
+    """
+    if not analysis_id:
+        with workdir():
+            log_str = get_log()
+    else:
+        log_str = get_log(analysis_id)
+
+    click.echo(log_str)
 
 
 @cli.command("status")

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -464,7 +464,7 @@ def log(analysis_id: str = None):
 
 
 @cli.command("status")
-@click.argument("analysis_id", type=str)
+@click.argument("analysis_id", type=str, required=False)
 @click.option(
     "--output-format",
     "-o",
@@ -472,9 +472,17 @@ def log(analysis_id: str = None):
     default="table",
     help="Specify output format for the status report.",
 )
-def status(analysis_id: str, output_format: str = None):
-    """Get status of an analysis."""
-    status_dict = get_status(analysis_id)
+def status(analysis_id: str = None, output_format: str = None):
+    """Get status of an analysis.
+
+    If ANALYSIS_ID is not provided, there will be used last analysis id, if noted by Thamos.
+    """
+    if not analysis_id:
+        with workdir():
+            status_dict = get_status()
+    else:
+        status_dict = get_status(analysis_id)
+
     if not output_format or output_format == "table":
         table = Texttable(max_width=get_terminal_size().columns)
         table.set_deco(Texttable.VLINES)

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -50,6 +50,7 @@ from .exceptions import UnknownAnalysisType
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+LAST_ANALYSIS_ID_FILE = ".thoth_last_analysis_id"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,6 +117,33 @@ def _wait_for_analysis(status_func: callable, analysis_id: str) -> None:
 
             sleep(sleep_time)
             sleep_time = min(sleep_time * 2, 10)
+
+
+def _note_last_analysis_id(analysis_id: str) -> None:
+    """Store analysis id in a temporary file to keep analysis id for thamos log optional."""
+    if int(os.getenv("THAMOS_DISABLE_LAST_ANALYSIS_ID_FILE", 0)):
+        _LOGGER.debug("Last analysis id will not be noted")
+        return
+
+    _LOGGER.debug("Noting last analysis id %r", analysis_id)
+    try:
+        with open(LAST_ANALYSIS_ID_FILE, "w") as analysis_id_file:
+            analysis_id_file.write(analysis_id)
+    except Exception as exc:
+        _LOGGER.warning("Failed to write analysis id to a temporary file: %s", str(exc))
+
+
+def _get_last_analysis_id() -> str:
+    """Retrieve last analysis id from a temporary file."""
+    try:
+        with open(LAST_ANALYSIS_ID_FILE, "r") as analysis_id_file:
+            analysis_id = analysis_id_file.readline().strip()
+    except Exception as exc:
+        raise FileNotFoundError(
+            "Cannot retrieve last analysis id, you need to provide analysis id explicitly"
+        ) from exc
+
+    return analysis_id
 
 
 def _retrieve_analysis_result(
@@ -260,6 +288,8 @@ def advise(
         thoth_config.api_url,
     )
 
+    _note_last_analysis_id(response.analysis_id)
+
     _LOGGER.debug("Analysis parameters:\n%r", pprint.pformat(parameters))
     _LOGGER.debug("Adviser input:\n%s", advise_input.to_str())
 
@@ -344,6 +374,9 @@ def provenance_check(
         response.analysis_id,
         thoth_config.api_url,
     )
+
+    _note_last_analysis_id(response.analysis_id)
+
     if nowait:
         return response.analysis_id
 
@@ -493,8 +526,14 @@ def build_analysis(
 
 
 @with_api_client
-def get_log(api_client: ApiClient, analysis_id: str):
-    """Get log of an analysis - the analysis type and endpoint are automatically derived from analysis id."""
+def get_log(api_client: ApiClient, analysis_id: str = None):
+    """Get log of an analysis - the analysis type and endpoint are automatically derived from analysis id.
+
+    If analysis_id is not provided, its get from the last thamos call which stores it in a temporary file.
+    """
+    if not analysis_id:
+        analysis_id = _get_last_analysis_id()
+
     if analysis_id.startswith("package-extract-"):
         api_instance = ImageAnalysisApi(api_client)
         method = api_instance.get_analyze_log

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -552,8 +552,14 @@ def get_log(api_client: ApiClient, analysis_id: str = None):
 
 
 @with_api_client
-def get_status(api_client: ApiClient, analysis_id: str):
-    """Get status of an analysis - the analysis type and endpoint are automatically derived from analysis id."""
+def get_status(api_client: ApiClient, analysis_id: str = None):
+    """Get status of an analysis - the analysis type and endpoint are automatically derived from analysis id.
+
+    If analysis_id is not provided, its get from the last thamos call which stores it in a temporary file.
+    """
+    if not analysis_id:
+        analysis_id = _get_last_analysis_id()
+
     if analysis_id.startswith("package-extract-"):
         api_instance = ImageAnalysisApi(api_client)
         method = api_instance.get_analyze_status


### PR DESCRIPTION
This will improve user experience when performing:
```
thamos advise or thamos provenance-check
```
and a subsequent:
```
thamos log
```
User does not need to provide analysis id explictly.