### PR TITLE
Adjust the exception message when file is not set

### DIFF
--- a/thamos/utils.py
+++ b/thamos/utils.py
@@ -44,7 +44,7 @@ def workdir(file_lookup: str = None):
         project_dir = os.path.dirname(project_dir)
     else:
         raise NoProjectDirError(
-            f"No {file_lookup} found in the current directory {project_dir!r} or in any of its parent "
+            f"No {file_lookup} found in the current directory {os.getcwd()!r} or in any of its parent "
             f"directories, you can generate it using '{sys.argv[0]} config'"
         )
 


### PR DESCRIPTION
This fix addresses an issue when the desired file is not found (e.g. Pipfile).
The error message always reported '/', now we report the original directory
where the lookup started.