### PR TITLE
remove unusued parameter

### DIFF
--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -214,7 +214,6 @@ def advise(
     github_check_run_id: typing.Optional[int] = None,
     github_installation_id: typing.Optional[int] = None,
     github_base_repo_url: typing.Optional[str] = None,
-    github_head_repo_url: typing.Optional[str] = None
 ) -> typing.Optional[tuple]:
     """Submit a stack for adviser checks and wait for results."""
     if not pipfile:
@@ -301,9 +300,6 @@ def advise(
     if github_installation_id is not None:
         parameters["github_installation_id"] = github_installation_id
 
-    if github_head_repo_url is not None:
-        parameters["github_head_repo_url"] = github_head_repo_url
-
     if github_base_repo_url is not None:
         parameters["github_base_repo_url"] = github_base_repo_url
 
@@ -352,8 +348,7 @@ def advise_here(
     github_event_type: typing.Optional[str] = None,
     github_check_run_id: typing.Optional[int] = None,
     github_installation_id: typing.Optional[int] = None,
-    github_base_repo_url: typing.Optional[str] = None,
-    github_head_repo_url: typing.Optional[str] = None
+    github_base_repo_url: typing.Optional[str] = None
 ) -> typing.Optional[tuple]:
     """Run advise in current directory, requires no arguments."""
     if not os.path.isfile("Pipfile"):
@@ -383,7 +378,6 @@ def advise_here(
             github_check_run_id=github_check_run_id,
             github_installation_id=github_installation_id,
             github_base_repo_url=github_base_repo_url,
-            github_head_repo_url=github_head_repo_url,
         )
 
 


### PR DESCRIPTION
Only `base_repo_url` is required for the GitHub App. Ref: https://github.com/goern/Qeb-Hwt/pull/15/files

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>