### PR TITLE
A temporary workaround for workload-operator and analysis propagation

### DIFF
--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -104,6 +104,7 @@ def _wait_for_analysis(status_func: callable, analysis_id: str) -> None:
 
     sleep_time = 0.5
     with spinner():
+        sleep(2)  # TODO: remove once we fully run on Argo workflows
         while True:
             response = status_func(analysis_id)
             if response.status.finished_at is not None:


### PR DESCRIPTION
When workload-operator is used, it takes some time to propagate cm into the cluster so its visible to status endpoint. Let's create this active wait until we fully port to argo which should tackle this problem.