### PR TITLE
Fix inconsistency in wait time printed

### DIFF
--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -128,7 +128,7 @@ def _wait_for_analysis(status_func: callable, analysis_id: str) -> None:
             if response.status.finished_at is not None:
                 break
             _LOGGER.debug(
-                "Waiting for %r to finish for %s seconds (state: %s)",
+                "Waiting for %r to finish for %g seconds (state: %s)",
                 analysis_id,
                 sleep_time,
                 response.status.state,


### PR DESCRIPTION
```
2020-04-29 07:17:44,276 [24] DEBUG    thamos.lib: Waiting for 'provenance-checker-a43703ef' to finish for 8.0 seconds (state: waiting)
2020-04-29 07:17:52,688 [24] DEBUG    thamos.lib: Waiting for 'provenance-checker-a43703ef' to finish for 8 seconds (state: waiting)
```