### PR TITLE
Perform status obtaining request only for debug level

### DIFF
--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -170,12 +170,14 @@ def _wait_for_analysis(status_func: Callable[..., Any], analysis_id: str) -> Non
             retries = 0  # Reset counter as we obtained a valid response.
             if response:
                 break
-            _LOGGER.debug(
-                "Waiting for %r to finish for %g seconds (state: %s)",
-                analysis_id,
-                sleep_time,
-                response,
-            )
+
+            if _LOGGER.getEffectiveLevel() <= logging.DEBUG:
+                _LOGGER.debug(
+                    "Waiting for %r to finish for %g seconds (state: %s)",
+                    analysis_id,
+                    sleep_time,
+                    (get_status(analysis_id) or {}).get("state", "N/A"),
+                )
 
             sleep(sleep_time)
             sleep_time = min(sleep_time * 2, 8)


### PR DESCRIPTION
The previous implementation always responded with "`status: False`" respecting
is_analysis_ready return value.

```console
2020-08-31 14:30:49,354 [400699] DEBUG    thamos.lib: Waiting for 'adviser-d1cd3915' to finish for 4 seconds (state: False)
```