### PR TITLE
Provide stack info when adviser fails

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -428,9 +428,19 @@ def advise(
         result, error = results
         if error:
             if json_output:
-                print({"error": result["error_msg"]})
+                json.dump(result, sys.stdout, indent=2)
             else:
-                print(result["error_msg"])
+                stack_info = result.get("report", {}).get("stack_info")
+                if stack_info:
+                    _print_report(
+                        stack_info,
+                        json_output=json_output,
+                        title="Application stack guidance",
+                    )
+                print(
+                    result.get("error_msg")
+                    or "No error message was provided by the service."
+                )
             sys.exit(4)
 
         if not no_write:


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/adviser/issues/1478

## This introduces a breaking change

- [x] No
