### PR TITLE
Notify users about requirements used and project root

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -126,7 +126,9 @@ def _write_files(
 
 
 def _write_configuration(
-    advised_configuration: dict, recommendation_type: str = None, dev: bool = False,
+    advised_configuration: dict,
+    recommendation_type: str = None,
+    dev: bool = False,
 ) -> None:
     """Create thoth configuration file."""
     if not advised_configuration:
@@ -667,7 +669,9 @@ def status(analysis_id: str = None, output_format: str = None):
 
         for key in status_dict.keys():
             table.add_column(
-                key.replace("_", " ").capitalize(), style="cyan", overflow="fold",
+                key.replace("_", " ").capitalize(),
+                style="cyan",
+                overflow="fold",
             )
 
         table.add_row(*status_dict.values())

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -88,10 +88,14 @@ def handle_cli_exception(func: typing.Callable) -> typing.Callable:
 def _load_files(requirements_format: str) -> Tuple[str, Optional[str]]:
     """Load Pipfile/Pipfile.lock or requirements.in/txt from the current directory."""
     if requirements_format == "pipenv":
+        _LOGGER.info("Using Pipenv files located in the project root directory")
         project = Project.from_files(
             without_pipfile_lock=not os.path.exists("Pipfile.lock")
         )
     elif requirements_format in ("pip", "pip-tools", "pip-compile"):
+        _LOGGER.info(
+            "Using requirements.txt file located in the project root directory"
+        )
         project = Project.from_pip_compile_files(allow_without_lock=True)
     else:
         raise ValueError(

--- a/thamos/utils.py
+++ b/thamos/utils.py
@@ -18,6 +18,7 @@
 """Utility and helper functions for Thamos."""
 
 from contextlib import contextmanager
+import logging
 import os
 import sys
 
@@ -26,6 +27,7 @@ from .exceptions import NoProjectDirError
 # Limit traversing to parent directories so we handle root - we do not loop over and over in root and we also
 # handle cyclic symlinks natively.
 _WORKDIR_DEPTH_LEN = 33
+_LOGGER = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -34,10 +36,13 @@ def workdir(file_lookup: str = None):
     file_lookup = file_lookup or ".thoth.yaml"
 
     project_dir = os.getcwd()
+    original_project_dir = project_dir
     for _ in range(_WORKDIR_DEPTH_LEN):
         file = os.path.join(project_dir, file_lookup)
         if os.path.isfile(file):
             with cwd(project_dir):
+                if project_dir != original_project_dir:
+                    _LOGGER.warning("Using %r as project root directory", project_dir)
                 yield project_dir
             break
 


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #609 

## This introduces a breaking change

- [x] No


```
thamos advise
2020-11-16 13:12:10,904 [69690] WARNING  thamos.utils: Using '/home/fpokorny/git/thoth-station/thamos/examples/' as project root directory
2020-11-16 13:12:10,906 [69690] INFO     thamos: Using requirements.txt file located in the project root directory
2020-11-16 13:12:11,893 [69690] INFO     thamos.lib: Performing static analysis of sources to gather library usage
2020-11-16 13:12:11,895 [69690] WARNING  thamos.lib: No library usage was aggregated - no Python sources found
2020-11-16 13:12:13,171 [69690] INFO     thamos.lib: Successfully submitted advise analysis 'adviser-890e2b50' to 'https://khemenu.thoth-station.ninja/api/v1'
```