### PR TITLE
Adjust datatype of parameters in _write_files method

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -26,6 +26,7 @@ from functools import wraps
 from typing import Tuple
 from typing import Optional
 from typing import Set
+from typing import Dict, Any
 
 import yaml
 import click
@@ -129,7 +130,7 @@ def _load_files(requirements_format: str) -> Tuple[str, Optional[str]]:
 
 
 def _write_files(
-    requirements: str, requirements_lock: str, requirements_format: str
+    requirements: Dict[str, Any], requirements_lock: Dict[str, Any], requirements_format: str
 ) -> None:
     """Write content of Pipfile/Pipfile.lock or requirements.in/txt to the current directory."""
     project = Project.from_dict(requirements, requirements_lock)


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Passing strings for requirements and requirement_lock to `_write_files` gives error:
```
      File "/home/fmurdaca/.local/share/virtualenvs/jupyterlab-requirements-wZBGhmnk/lib/python3.8/site-packages/tornado/web.py", line 1702, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File "/home/fmurdaca/.local/share/virtualenvs/jupyterlab-requirements-wZBGhmnk/lib/python3.8/site-packages/tornado/web.py", line 3173, in wrapper
        return method(self, *args, **kwargs)
      File "/home/fmurdaca/work/aicoe/jupyterlab-requirements/jupyterlab_requirements/dependency_management/dependencies.py", line 62, in post
        _write_files(
      File "/home/fmurdaca/work/aicoe/jupyterlab-requirements/jupyterlab_requirements/dependency_management/dependencies.py", line 78, in _write_files
        project = Project.from_dict(requirements, requirements_lock)
      File "/home/fmurdaca/.local/share/virtualenvs/jupyterlab-requirements-wZBGhmnk/lib/python3.8/site-packages/thoth/python/project.py", line 114, in from_dict
        pipfile = Pipfile.from_dict(pipfile)
      File "/home/fmurdaca/.local/share/virtualenvs/jupyterlab-requirements-wZBGhmnk/lib/python3.8/site-packages/thoth/python/pipfile.py", line 341, in from_dict
        packages = dict_.pop("packages", {})
    AttributeError: 'str' object has no attribute 'pop'

```

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Adjust datatype for method `_write_files` as dict are expected and not string.