### PR TITLE
Load configuration just once and avoid misleading warnings

### DIFF
--- a/thamos/config.py
+++ b/thamos/config.py
@@ -208,10 +208,11 @@ class _Configuration:
 
             self._configuration = yaml.safe_load(self._configuration)
 
-    def load_config(self) -> None:
+    def load_config(self, force: bool = False) -> None:
         """Load configuration from a file."""
-        with workdir(config.CONFIG_NAME):
-            self.load_config_from_file(config.CONFIG_NAME)
+        if not self._configuration and not force:
+            with workdir(config.CONFIG_NAME):
+                self.load_config_from_file(config.CONFIG_NAME)
 
     def create_default_config(
         self, template: str = None, nowrite: bool = False

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -521,7 +521,9 @@ def advise_here(
     """Run advise in current directory, requires no arguments."""
     requirements_format = thoth_config.requirements_format
     if requirements_format == "pipenv":
-        _LOGGER.info("Using Pipenv files located in the project root directory")
+        _LOGGER.info(
+            "Using Pipenv files to manage dependencies located in %r", os.getcwd()
+        )
         pipfile_lock_exists = os.path.exists("Pipfile.lock")
 
         if pipfile_lock_exists:
@@ -547,7 +549,8 @@ def advise_here(
             )
     elif requirements_format in ("pip", "pip-tools", "pip-compile"):
         _LOGGER.info(
-            "Using requirements.txt file located in the project root directory"
+            "Using requirements.txt file to manage dependencies located in %r",
+            os.getcwd(),
         )
         project = Project.from_pip_compile_files(allow_without_lock=True)
     else:

--- a/thamos/utils.py
+++ b/thamos/utils.py
@@ -17,6 +17,7 @@
 
 """Utility and helper functions for Thamos."""
 
+from typing import Optional
 from contextlib import contextmanager
 import logging
 import os
@@ -31,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @contextmanager
-def workdir(file_lookup: str = None):
+def workdir(file_lookup: Optional[str] = None, warn_on_dir_change: bool = True) -> None:
     """Find project directory and cd into it."""
     file_lookup = file_lookup or ".thoth.yaml"
 
@@ -41,7 +42,7 @@ def workdir(file_lookup: str = None):
         file = os.path.join(project_dir, file_lookup)
         if os.path.isfile(file):
             with cwd(project_dir):
-                if project_dir != original_project_dir:
+                if project_dir != original_project_dir and warn_on_dir_change:
                     _LOGGER.warning("Using %r as project root directory", project_dir)
                 yield project_dir
             break


### PR DESCRIPTION
Multiple warnings produced during analysis waiting were removed with this change. Also, the messages produced should be more accurate now.

## This introduces a breaking change

- [x] No
