### PR TITLE
Allow nullables in post build analysis response

### DIFF
--- a/Documentation/BuildAnalysisResponse.md
+++ b/Documentation/BuildAnalysisResponse.md
@@ -3,9 +3,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**base_image_analysis** | [**BuildAnalysisResponseBaseImageAnalysis**](BuildAnalysisResponseBaseImageAnalysis.md) |  |
-**output_image_analysis** | [**BuildAnalysisResponseBaseImageAnalysis**](BuildAnalysisResponseBaseImageAnalysis.md) |  |
-**buildlog_analysis** | [**BuildAnalysisResponseBaseImageAnalysis**](BuildAnalysisResponseBaseImageAnalysis.md) |  |
+**base_image_analysis** | [**BuildAnalysisResponseBaseImageAnalysis**](BuildAnalysisResponseBaseImageAnalysis.md) |  | [optional]
+**output_image_analysis** | [**BuildAnalysisResponseBaseImageAnalysis**](BuildAnalysisResponseBaseImageAnalysis.md) |  | [optional]
+**buildlog_analysis** | [**BuildAnalysisResponseBaseImageAnalysis**](BuildAnalysisResponseBaseImageAnalysis.md) |  | [optional]
 **buildlog_document_id** | **str** | Document identifier for the stored build log. | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/thamos/swagger_client/models/build_analysis_response.py
+++ b/thamos/swagger_client/models/build_analysis_response.py
@@ -56,9 +56,12 @@ class BuildAnalysisResponse(object):
         self._buildlog_analysis = None
         self._buildlog_document_id = None
         self.discriminator = None
-        self.base_image_analysis = base_image_analysis
-        self.output_image_analysis = output_image_analysis
-        self.buildlog_analysis = buildlog_analysis
+        if base_image_analysis is not None:
+            self.base_image_analysis = base_image_analysis
+        if output_image_analysis is not None:
+            self.output_image_analysis = output_image_analysis
+        if buildlog_analysis is not None:
+            self.buildlog_analysis = buildlog_analysis
         if buildlog_document_id is not None:
             self.buildlog_document_id = buildlog_document_id
 
@@ -80,10 +83,6 @@ class BuildAnalysisResponse(object):
         :param base_image_analysis: The base_image_analysis of this BuildAnalysisResponse.  # noqa: E501
         :type: BuildAnalysisResponseBaseImageAnalysis
         """
-        if base_image_analysis is None:
-            raise ValueError(
-                "Invalid value for `base_image_analysis`, must not be `None`"
-            )  # noqa: E501
 
         self._base_image_analysis = base_image_analysis
 
@@ -105,10 +104,6 @@ class BuildAnalysisResponse(object):
         :param output_image_analysis: The output_image_analysis of this BuildAnalysisResponse.  # noqa: E501
         :type: BuildAnalysisResponseBaseImageAnalysis
         """
-        if output_image_analysis is None:
-            raise ValueError(
-                "Invalid value for `output_image_analysis`, must not be `None`"
-            )  # noqa: E501
 
         self._output_image_analysis = output_image_analysis
 
@@ -130,10 +125,6 @@ class BuildAnalysisResponse(object):
         :param buildlog_analysis: The buildlog_analysis of this BuildAnalysisResponse.  # noqa: E501
         :type: BuildAnalysisResponseBaseImageAnalysis
         """
-        if buildlog_analysis is None:
-            raise ValueError(
-                "Invalid value for `buildlog_analysis`, must not be `None`"
-            )  # noqa: E501
 
         self._buildlog_analysis = buildlog_analysis
 


### PR DESCRIPTION
## Related Issues and Dependencies

```
Traceback (most recent call last):
  File "app.py", line 343, in _submitter
    _do_analyze_build(
  File "app.py", line 216, in _do_analyze_build
    analysis_response = build_analysis(
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/lib.py", line 102, in wrapper
    result = func(api_client, *args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/lib.py", line 758, in build_analysis
    response = api_instance.post_build(**params)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/thoth/build_analysis_api.py", line 63, in post_build
    (data) = self.post_build_with_http_info(body, **kwargs)  # noqa: E501
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/thoth/build_analysis_api.py", line 187, in post_build_with_http_info
    return self.api_client.call_api(
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 343, in call_api
    return self.__call_api(
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 174, in __call_api
    return_data = self.deserialize(response_data, response_type)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 247, in deserialize
    return self.__deserialize(data, response_type)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 286, in __deserialize
    return self.__deserialize_model(data, klass)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 691, in __deserialize_model
    instance = klass(**kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/models/build_analysis_response.py", line 59, in __init__
    self.base_image_analysis = base_image_analysis
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/models/build_analysis_response.py", line 84, in base_image_analysis
    raise ValueError(
ValueError: Invalid value for `base_image_analysis`, must not be `None`
```

## This introduces a breaking change

- [x] No
