### PR TITLE
Add support for passing options to pip during thamos install

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -379,13 +379,16 @@ def _print_version(ctx, json_output: bool = False):
     envvar="THAMOS_RUNTIME_ENVIRONMENT",
     help="Specify explicitly runtime environment for which the installation process should be done.",
 )
-def install(runtime_environment: str, dev: bool) -> None:
+@click.argument("pip_args", nargs=-1)
+def install(runtime_environment: str, dev: bool, pip_args: Tuple[str]) -> None:
     """Install dependencies as stated in Pipfile.lock or requirements.txt.
 
     This command assumes requirements files are present and dependencies are already resolved.
     If that's not the case, issue `thamos advise` before calling this.
     """
-    thamos_install(runtime_environment_name=runtime_environment, dev=dev)
+    thamos_install(
+        runtime_environment_name=runtime_environment, dev=dev, pip_args=pip_args
+    )
 
 
 @cli.command("advise")

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -900,7 +900,9 @@ def install_using_config(
 
 
 def install(
-    runtime_environment_name: typing.Optional[str] = None, dev: bool = False
+    runtime_environment_name: typing.Optional[str] = None,
+    dev: bool = False,
+    pip_args: typing.Optional[typing.Tuple[str]] = None,
 ) -> None:
     """Perform installation of packages for the given runtime environment.
 
@@ -936,7 +938,7 @@ def install(
             method,
             os.getcwd(),
         )
-        micropipenv.install(method=method, deploy=True, dev=dev)
+        micropipenv.install(method=method, deploy=True, dev=dev, pip_args=pip_args)
 
 
 @with_api_client


### PR DESCRIPTION
## Related Issues and Dependencies

```console
thamos install -- --user  # issues pip install --user under the hood.
```

Related-To: #723 

## This introduces a breaking change

- [x] No
