### PR TITLE
Correctly pass debug option to provenance-check command

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -643,7 +643,6 @@ def advise(
     envvar="THAMOS_FORCE",
     help="Force analysis run bypassing server-side cache.",
 )
-@click.pass_context
 @handle_cli_exception
 def provenance_check(
     debug: bool = False,


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
