### PR TITLE
Add warning message when repo setup might be misleading

### DIFF
--- a/thamos/config.py
+++ b/thamos/config.py
@@ -574,6 +574,18 @@ class _Configuration:
                 }
             )
 
+        if self.content.get("overlays_dir"):
+            with workdir():
+                for file_type in ("Pipfile", "Pipfile.lock", "requirements.txt", "requirements.in"):
+                    if os.path.isfile(file_type):
+                        result.append(
+                            {
+                                "message": f"Overlays configured but {file_type!r} file found in the repo root, "
+                                           f"this might lead to misleading repository interpretation",
+                                "type": "WARNING",
+                            }
+                        )
+
         if runtime_environment_name is not None:
             result.extend(self.check_runtime_environment(runtime_environment_name))
         else:


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thamos/issues/742

## This introduces a breaking change

- [x] No
