### PR TITLE
Do not show Warehouse API url in the index listing

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1070,6 +1070,8 @@ def indexes(output_format: str) -> None:
         header = set()
         for item in result:
             for key in item.keys():
+                if key == "warehouse_api_url":
+                    continue
                 header.add(key)
 
         header_sorted = sorted(header)

--- a/thamos/config.py
+++ b/thamos/config.py
@@ -576,12 +576,17 @@ class _Configuration:
 
         if self.content.get("overlays_dir"):
             with workdir():
-                for file_type in ("Pipfile", "Pipfile.lock", "requirements.txt", "requirements.in"):
+                for file_type in (
+                    "Pipfile",
+                    "Pipfile.lock",
+                    "requirements.txt",
+                    "requirements.in",
+                ):
                     if os.path.isfile(file_type):
                         result.append(
                             {
                                 "message": f"Overlays configured but {file_type!r} file found in the repo root, "
-                                           f"this might lead to misleading repository interpretation",
+                                f"this might lead to misleading repository interpretation",
                                 "type": "WARNING",
                             }
                         )

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -963,4 +963,6 @@ def list_thoth_s2i(api_client: ApiClient) -> typing.Dict[str, Any]:
 @with_api_client
 def list_python_package_indexes(api_client: ApiClient) -> typing.Dict[str, Any]:
     """Get information about hardware for which Thoth can give recommendations."""
-    return PythonPackagesApi(api_client).list_python_package_indexes().to_dict()["indexes"]
+    return (
+        PythonPackagesApi(api_client).list_python_package_indexes().to_dict()["indexes"]
+    )


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

There is no reason why this should be shown to users. Show just the index url and the fact if it is verified using TLS.
