### PR TITLE
allow aicoe-ci to release the module to pypi

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,3 +1,5 @@
 check:
   - thoth-precommit
   - thoth-pytest-py38
+release:
+  - upload-pypi-sesheta


### PR DESCRIPTION
allow aicoe-ci to release the module to pypi
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

with current updates to aicoe-ci, some of the default methods are made to be configured in config file to be used. 