### PR TITLE
Exclude autogenerated code from pre-commit

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,3 +2,6 @@
 disable_error_code = misc
 show_error_codes = True
 files = **/*.py
+
+[mypy-thamos.swagger_client.*]
+ignore_errors = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,13 +28,13 @@ repos:
     rev: 5.1.1
     hooks:
       - id: pydocstyle
-        exclude: "thamos/swagger_client/*|docs/*"
+        exclude: "thamos/swagger_client/|docs/"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.790
     hooks:
       - id: mypy
-        exclude: (x)(^(docs|tasks|tests)|setup\.py|examples/*|swagger_client/)
+        exclude: (x)(^(docs|tasks|tests)|setup\.py|examples/|swagger_client/)
         args: ["--scripts-are-modules", "--ignore-missing-imports"]
         additional_dependencies: [attrs~=19.3]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+exclude: "thamos/swagger_client/|docs/"
 repos:
   - repo: git://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,32 +9,26 @@ repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0
     hooks:
-      - id: trailing-whitespace
-      - id: check-merge-conflict
-      - id: end-of-file-fixer
       - id: check-added-large-files
+      - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-json
+      - id: check-merge-conflict
       - id: check-symlinks
-      - id: detect-private-key
-      - id: check-ast
+      - id: check-toml
+      - id: check-yaml
       - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
 
   - repo: git://github.com/pycqa/pydocstyle.git
     rev: 5.1.1
     hooks:
       - id: pydocstyle
         exclude: "thamos/swagger_client/*|docs/*"
-
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
-    hooks:
-      - id: check-toml
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.790

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: "thamos/swagger_client/|docs/"
+exclude: "thamos/swagger_client/|docs/|Documentation"
 repos:
   - repo: git://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,6 @@ repos:
     hooks:
       - id: mypy
         exclude: "docs/|tasks/|tests/|setup.py|thamos/swagger_client/|examples/"
-        # exclude: (x)(^(docs|tasks|tests)|setup\.py|examples/|swagger_client/)
         args: ["--scripts-are-modules", "--ignore-missing-imports"]
         additional_dependencies: [attrs~=19.3]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,8 @@ repos:
     rev: v0.790
     hooks:
       - id: mypy
-        exclude: (x)(^(docs|tasks|tests)|setup\.py|examples/|swagger_client/)
+        exclude: "docs/|tasks/|tests/|setup.py|thamos/swagger_client/|examples/"
+        # exclude: (x)(^(docs|tasks|tests)|setup\.py|examples/|swagger_client/)
         args: ["--scripts-are-modules", "--ignore-missing-imports"]
         additional_dependencies: [attrs~=19.3]
 


### PR DESCRIPTION
## Related Issues and Dependencies
resoves #540 
…

## This introduces a breaking change

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

global exclusions in pre-commit commit and minor clean-up

## Description

This PR relates to #540. It attempts to exclude auto-generated code from being in pre-commit hooks via a global exclude statement at the top of the config file. I also added a section in the .mypy.ini config to exclude the swagger_client. That was necessary due to it being imported some of the core code. 

I couldn't tell if there was more auto-generated code/directories than the three listed `thamos/swagger_client/|docs/|Documentation` 

A bit of cleanup:

-  removed a bit duplication in the pre-commit config, and sorted the entries for the  ` - repo: git://github.com/pre-commit/pre-commit-hooks` - I'm assuming order doesn't matter here.
- I tried to leave the hook specific exclusions alone, but did remove the `*` from the paths, as those were throwing a warning when being run

I did some testing locally, and it seemed to behave as expected, but I don't know that it was 'comprehensive', or if y'all have a way you like to test changing pre-commit config.
