### PR TITLE
Issue an error if a user tries to install missing dev requirements

### DIFF
--- a/thamos/exceptions.py
+++ b/thamos/exceptions.py
@@ -68,3 +68,7 @@ class ApiError(ThamosException):
 
 class NoRequirementsFile(ThamosException):
     """An exception raised when requirements file is not present."""
+
+
+class NoDevRequirements(ThamosException):
+    """An exception raised if no development requirements are found during the installation process."""

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -60,6 +60,7 @@ from .config import config as thoth_config
 from .exceptions import UnknownAnalysisType
 from .exceptions import TimeoutError
 from .exceptions import ApiError
+from .exceptions import NoDevRequirements
 from .exceptions import NoRequirementsFile
 
 from typing import Callable, Any, Union, Dict
@@ -935,6 +936,19 @@ def install(
                 raise NoRequirementsFile(
                     f"No Pipfile found in {os.getcwd()!r} needed for the installation process"
                 )
+
+            if dev:
+                with open("Pipfile.lock") as pipfile_lock_file:
+                    content = json.load(pipfile_lock_file)
+
+                if not content.get("develop"):
+                    raise NoDevRequirements(
+                        "No development requirements found in the lock file, make sure development "
+                        "requirements are stated and the resolved stack preserves them by "
+                        "using `thamos advise --dev`"
+                    )
+
+                del content
         else:
             if not os.path.isfile("requirements.txt"):
                 raise NoRequirementsFile(


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

If no development requirements are present and the user issues `thamos install --dev`, the command passes silently. We should report an error to the user.