### PR TITLE
Add URL Home page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     name="thamos",
     entry_points={"console_scripts": ["thamos=thamos.cli:cli"]},
     version=VERSION,
+    url="https://github.com/thoth-station/thamos",
     package_data={"thamos": [os.path.join("data", "*.yaml"), "py.typed"]},
     include_package_data=True,
     description="A CLI tool and library for interacting with Thoth",


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies
```
Name: thamos
Version: 1.16.0
Summary: A CLI tool and library for interacting with Thoth
Home-page: UNKNOWN
Author: Fridolin Pokorny
Author-email: fridolin@redhat.com
License: GPLv3+
Location: /home/fmurdaca/.local/share/virtualenvs/jupyterlab-requirements-wZBGhmnk/lib/python3.8/site-packages
Requires: six, virtualenv, termcolor, distro, setuptools, certifi, thoth-analyzer, requests, rich, micropipenv, pyyaml, daiquiri, yaspin, click, urllib3, thoth-common, jsonschema, invectio, python-dateutil, thoth-python
Required-by: jupyterlab-requirements
```

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add Home-page URL pointing to thamos repo from PyPI
