### PR TITLE
Adjust TimeoutError message

### DIFF
--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -163,7 +163,7 @@ def _wait_for_analysis(
             if timeout and monotonic() - start_time > timeout:
                 raise TimeoutError(
                     f"Thoth backend did not respond in time, timeout set "
-                    f"to {_THAMOS_TIMEOUT} - see {jl('thamos_timeout')}"
+                    f"to {timeout} - see {jl('thamos_timeout')}"
                 )
             try:
                 response = status_func(analysis_id)


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Set the timeout to 60s using advise_from_config method from thamos library and the message was:

```
error locking dependencies using Thoth: Thoth backend did not respond in time, timeout set to 2000 - see https://thoth-station.ninja/j/thamos_timeout
```

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Fix Timeout Error message
