### PR TITLE
Virtualenv cli_run is available since 20.0.3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,7 +22,7 @@ thoth-common = "*"
 rich = "*"
 micropipenv = "*"
 jsonschema = "*"
-virtualenv = "*"
+virtualenv = ">=20.0.3"
 
 [dev-packages]
 toml = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1c99700839bdebb4bafe4636eab8a421cad0be055f97a206e838b99737944077"
+            "sha256": "a67ae498b6912498cb36210e51b49456884424859ad7cccb45f4bd895bc8ab67"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ thoth-common
 rich
 micropipenv
 jsonschema
-virtualenv
+virtualenv>=20.0.3


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/pypa/virtualenv/pull/1592/commits/079f6db84a3f43c31b6025fe60cfbebf2a4b1182
Closes: https://github.com/thoth-station/thamos/issues/846
Closes: https://github.com/thoth-station/thoth-toolbox/issues/9

## This introduces a breaking change

- [x] No
