### PR TITLE
Require at least one runtime environment set in the config file

### DIFF
--- a/thamos/config.py
+++ b/thamos/config.py
@@ -119,6 +119,7 @@ _CONFIG_SCHEMA = {
         "runtime_environments": {
             "type": "array",
             "items": _CONFIG_RUNTIME_ENVIRONMENT_SCHEMA,
+            "minItems": 1,
         },
         "managers": {
             "type": "array",


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
