### PR TITLE
Use latest recommendations by default

### DIFF
--- a/thamos/data/defaultThoth.yaml
+++ b/thamos/data/defaultThoth.yaml
@@ -37,7 +37,7 @@ runtime_environments:
     #  * performance
     #  * security
     # See https://thoth-station.ninja/recommendation-types/
-    recommendation_type: stable
+    recommendation_type: latest
     # Platform used for running the application - corresponds to sysconfig.get_platform() call (e.g. 'linux-x86_64')
     platform: {platform}
     # Additional options:


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

Let's use `latest` recommendation type by default to be "pipenv/pip" compliant on an initial setup without any config changes. Other recommendation types take longer to resolve stacks - that might be something not user friendly to newcomers who explore Thoth.