### PR TITLE
Update the labels of bug/rfe issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: bug
+labels: kind/bug
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: enhancement
+labels: kind/feature
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
## Related Issues and Dependencies

#925 was apparently created using the bug template, but it was not labeled as a bug

## This Pull Request implements

Include kind/ prefix in the labels for bugs and features.

