### PR TITLE
Use https in pre-commit repo links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 exclude: "thamos/swagger_client/|docs/|Documentation"
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.9
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
       - id: check-added-large-files
@@ -24,7 +24,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: git://github.com/pycqa/pydocstyle.git
+  - repo: https://github.com/pycqa/pydocstyle.git
     rev: 5.1.1
     hooks:
       - id: pydocstyle


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/thoth-application/issues/2111

## This Pull Request implements

Update the pre-commit configuration to use https: instead of git:

## Description

From https://github.com/thoth-station/thoth-application/issues/2111:

GitHub has recently upgraded its clone methods for more security. It would no longer support the SHA-1 method.
November 2, 2021, was the deadline to switch, hence we are facing the issue.
Details: https://github.blog/2021-09-01-improving-git-protocol-security-github/#dropping-insecure-signature-algorithms

pre-commit checks did not fail for this repo yet (it just worked fine #926), but I believe they are bound to fail without this change.