### PR TITLE
Feature/use new endpoint

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1383,9 +1383,16 @@ def support(output: str) -> None:
 @click.argument("import_name", type=str, required=True)
 def whatprovides(import_name: str) -> List[str]:
     """For a given import_name returns list of (package_name, package_version, index_url) triplets"""
+    _LOGGER.info(
+        "Returning information on package %r", import_name
+    )
     result = get_package_from_imported_packages(import_name)
-    # returns list of
-    # [{"package_name": i[0], "package_version": i[1], "index_url": i[2]} for i in query.all()]
+
+    console = Console()
+    console.print(result, justify="center")
+
+    sys.exit(0)
+
 
 @cli.command("discover")
 @click.argument("import_name", type=str, required=True)
@@ -1396,11 +1403,16 @@ def discover(import_name: str) -> str:
       thamos discover "dotenv"
       thamos discover "sklearn"
     """
+    _LOGGER.info(
+        "Identifying correct package names for %r",import_name
+    )
+    list = whatprovides(import_name)
 
-    # logic:
-    # 1. call command `invectio whatuses .`
-    # 2. run command to get correct names of packages
-    # 3. return list
-
+    with open('requirements.txt', 'w') as d:
+        for item in list:
+            _LOGGER.info(
+            "Adding package %r to requirements.txt", item["package_name"]
+            )
+            d.write(item["package_name"])
 
 __name__ == "__main__" and cli()

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -48,14 +48,16 @@ from thamos.lib import advise_here as thoth_advise_here
 from thamos.lib import collect_support_information_dict
 from thamos.lib import get_log
 from thamos.lib import get_package_from_imported_packages
+from thamos.lib import get_static_analysis
 from thamos.lib import get_status
 from thamos.lib import install as thamos_install
 from thamos.lib import list_python_package_indexes
 from thamos.lib import list_thoth_container_images
 from thamos.lib import load_files
 from thamos.lib import provenance_check as thoth_provenance_check
-from thamos.lib import write_configuration
 from thamos.lib import print_dependency_graph
+from thamos.lib import get_verified_packages_from_static_analysis
+from thamos.lib import write_configuration
 from thamos.lib import write_files
 from thamos.utils import workdir
 from thamos import __version__ as thamos_version
@@ -1391,7 +1393,7 @@ def support(output: str) -> None:
 )
 @click.argument("import_name", type=str, required=True)
 @handle_cli_exception
-def whatprovides(import_name: str, output_format: str) -> typing.List[str]:
+def whatprovides(import_name: str, output_format: str) -> None:
     """For a given import_name returns list of (package_name, package_version, index_url) triplets.
 
     Examples:
@@ -1434,18 +1436,25 @@ def whatprovides(import_name: str, output_format: str) -> typing.List[str]:
 
 @cli.command("discover")
 @click.pass_context
+@click.option(
+    "--src-path",
+    "-sp",
+    type=str,
+    default=".",
+    envvar="THAMOS_SOURCE_PATH",
+    help="Specify path to consider to discover packages.",
+)
 @handle_cli_exception
-def discover() -> str:
+def discover(src_path: str = ".") -> None:
     """Discover packages used in the project.
 
     Examples:
       thamos discover
     """
-    # 1. Obtain list of imports using invectio
+    # Obtain list of imports using invectio and verify package from PyPI
+    verified_packages = get_verified_packages_from_static_analysis(src_path=src_path)
 
-    # 2. For each import verify package (name, version, index) (whatprovides logic)
-
-    # 3. Update requirements files (Pipfile/Pipfile.lock) or requirements.txt (requirements logic)
+    # Update requirements files (Pipfile/Pipfile.lock) or requirements.txt (requirements logic)
 
 
 __name__ == "__main__" and cli()

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1379,6 +1379,14 @@ def support(output: str) -> None:
             json.dump(info, output_file, sort_keys=True, indent=2)
 
 
+@cli.command("whatprovides")
+@click.argument("import_name", type=str, required=True)
+def whatprovides(import_name: str) -> List[str]:
+    """For a given import_name returns list of (package_name, package_version, index_url) triplets"""
+    result = get_package_from_imported_packages(import_name)
+    # returns list of
+    # [{"package_name": i[0], "package_version": i[1], "index_url": i[2]} for i in query.all()]
+
 @cli.command("discover")
 @click.argument("import_name", type=str, required=True)
 def discover(import_name: str) -> str:

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -101,7 +101,7 @@ def handle_cli_exception(func: typing.Callable) -> typing.Callable:
     return wrapper
 
 
-def _print_report(report: dict, json_output: bool = False, title: Optional[str] = None):
+def _print_report(report: list, json_output: bool = False, title: Optional[str] = None):
     """Print reasoning to user."""
     if json_output:
         click.echo(json.dumps(report, sort_keys=True, indent=2))

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -45,10 +45,10 @@ from thamos.exceptions import NoProjectDirError
 from thamos.exceptions import NoRuntimeEnvironmentError
 from thamos.config import config as configuration
 from thamos.lib import advise_here as thoth_advise_here
+from thamos.lib import add_requirements_to_project
 from thamos.lib import collect_support_information_dict
 from thamos.lib import get_log
 from thamos.lib import get_package_from_imported_packages
-from thamos.lib import get_static_analysis
 from thamos.lib import get_status
 from thamos.lib import install as thamos_install
 from thamos.lib import list_python_package_indexes
@@ -1277,28 +1277,12 @@ def add(
 
       thamos add 'importlib-metadata; python_version < "3.8"'
     """
-    project = configuration.get_project(runtime_environment, missing_dir_ok=True)
-    for req in requirement:
-        _LOGGER.info(
-            "Adding %r to %s requirements of runtime environment %r",
-            req,
-            "development" if dev else "default",
-            project.runtime_environment.name,
-        )
-        project.pipfile.add_requirement(
-            req, is_dev=dev, index_url=index_url, force=True
-        )
-        runtime_environment_config = configuration.get_runtime_environment(
-            runtime_environment
-        )
-        python_version = runtime_environment_config.get("python_version")
-        if python_version:
-            project.set_python_version(python_version)
-
-    _LOGGER.warning(
-        "Changes done might require triggering new advise to resolve dependencies"
+    add_requirements_to_project(
+        requirement=requirement,
+        runtime_environment=runtime_environment,
+        index_url=index_url,
+        dev=dev,
     )
-    configuration.save_project(project)
 
 
 @cli.command("remove")
@@ -1444,8 +1428,16 @@ def whatprovides(import_name: str, output_format: str) -> None:
     envvar="THAMOS_SOURCE_PATH",
     help="Specify path to consider to discover packages.",
 )
+@click.option(
+    "--runtime-environment",
+    "-r",
+    default=None,
+    metavar="NAME",
+    envvar="THAMOS_RUNTIME_ENVIRONMENT",
+    help="Specify runtime environment to which the given package should be added.",
+)
 @handle_cli_exception
-def discover(src_path: str = ".") -> None:
+def discover(runtime_environment: typing.Optional[str], src_path: str = ".") -> None:
     """Discover packages used in the project.
 
     Examples:
@@ -1455,6 +1447,12 @@ def discover(src_path: str = ".") -> None:
     verified_packages = get_verified_packages_from_static_analysis(src_path=src_path)
 
     # Update requirements files (Pipfile/Pipfile.lock) or requirements.txt (requirements logic)
+    add_requirements_to_project(
+        requirement=verified_packages,
+        runtime_environment=runtime_environment,
+        index_url="https://pypi.org/simple",
+        dev=False,
+    )
 
 
 __name__ == "__main__" and cli()

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1381,7 +1381,7 @@ def support(output: str) -> None:
 
 @cli.command("whatprovides")
 @click.argument("import_name", type=str, required=True)
-def whatprovides(import_name: str) -> List[str]:
+def whatprovides(import_name: str) -> typing.List[str]:
     """For a given import_name returns list of (package_name, package_version, index_url) triplets"""
     _LOGGER.info(
         "Returning information on package %r", import_name

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1379,4 +1379,20 @@ def support(output: str) -> None:
             json.dump(info, output_file, sort_keys=True, indent=2)
 
 
+@cli.command("discover")
+@click.argument("import_name", type=str, required=True)
+def discover(import_name: str) -> str:
+    """Identify correct package names from PyPi for given import name.
+    Examples:
+      thamos discover "scikitplot"
+      thamos discover "dotenv"
+      thamos discover "sklearn"
+    """
+
+    # logic:
+    # 1. call command `invectio whatuses .`
+    # 2. run command to get correct names of packages
+    # 3. return list
+
+
 __name__ == "__main__" and cli()

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1178,11 +1178,18 @@ def get_package_from_imported_packages(
     api_client: ApiClient, import_name: str
 ) -> typing.List[Dict[str, Any]]:
     """Get all (package_name, package_version, index_url) triplets for given import package name."""
-    return (
-        PythonPackagesApi(api_client)
-        .get_package_from_imported_packages(import_name)
-        .to_dict()["package_names"]
-    )
+    result = []
+    try:
+        result = (
+            PythonPackagesApi(api_client)
+            .get_package_from_imported_packages(import_name)
+            .to_dict()["package_names"]
+        )
+    except Exception as error:
+        body_response = getattr(error, "body")
+        _LOGGER.error(json.loads(body_response)["error"])
+
+    return result
 
 
 def get_verified_packages_from_static_analysis(src_path: str = "."):
@@ -1235,8 +1242,10 @@ def get_verified_packages_from_static_analysis(src_path: str = "."):
                         f"Package name {unique_package['package_name']} identifed for import name {import_name}"
                     )
 
-        except Exception as e:
-            _LOGGER.warning(e)
+        except Exception as error:
+            _LOGGER.warning(
+                f"No packages identified for import name {import_name}: {error}"
+            )
 
     return verified_packages
 

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1174,7 +1174,7 @@ def list_python_package_indexes(api_client: ApiClient) -> typing.Dict[str, Any]:
 
 
 @with_api_client
-def get_package_from_imported_packages(api_client: ApiClient, import_name: str) -> List[str]:
+def get_package_from_imported_packages(api_client: ApiClient, import_name: str) -> typing.List[str]:
     """Get all (package_name, package_version, index_url) triplets for given import package name."""
     return (
         PythonPackagesApi(api_client).get_package_from_imported_packages(import_name)["package_names"]

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1174,10 +1174,14 @@ def list_python_package_indexes(api_client: ApiClient) -> typing.Dict[str, Any]:
 
 
 @with_api_client
-def get_package_from_imported_packages(api_client: ApiClient, import_name: str) -> typing.List[str]:
+def get_package_from_imported_packages(
+    api_client: ApiClient, import_name: str
+) -> typing.List[Dict[str, Any]]:
     """Get all (package_name, package_version, index_url) triplets for given import package name."""
     return (
-        PythonPackagesApi(api_client).get_package_from_imported_packages(import_name)["package_names"]
+        PythonPackagesApi(api_client)
+        .get_package_from_imported_packages(import_name)
+        .to_dict()["package_names"]
     )
 
 

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1173,6 +1173,14 @@ def list_python_package_indexes(api_client: ApiClient) -> typing.Dict[str, Any]:
     )
 
 
+@with_api_client
+def get_package_from_imported_packages(api_client: ApiClient, import_name: str) -> List[str]:
+    """Get all (package_name, package_version, index_url) triplets for given import package name."""
+    return (
+        PythonPackagesApi(api_client).get_package_from_imported_packages(import_name)["package_names"]
+    )
+
+
 def write_files(
     requirements: typing.Dict[str, Any],
     requirements_lock: typing.Dict[str, Any],


### PR DESCRIPTION
## Related Issues and Dependencies

Include changes from https://github.com/thoth-station/thamos/pull/917 made by @tlegen-k 

two new commands using import name endpoint

`whatprovides`:

![Screenshot from 2021-11-18 14-35-44](https://user-images.githubusercontent.com/27498679/142434886-5b845ca3-460e-4010-a0cf-b65b39f99c56.png)

multiple results to be fixed by: https://github.com/thoth-station/storages/pull/2480, https://github.com/thoth-station/user-api/pull/1517

`discover`:
```
(thamos) [fmurdaca@pc-7 15:09:08 ~/work/aicoe/thamos](feature/use-new-endpoint)$ thamos discover -sp './test.py' 
2021-11-18 15:20:15,952 [136924] INFO     thamos.lib: Performing static analysis of sources to gather library usage
2021-11-18 15:20:15,955 [136924] WARNING  thamos.config: TLS verification turned off, its highly recommended to use a secured connection, see configuration file for configuration options
2021-11-18 15:20:18,505 [136924] INFO     thamos.lib: Package name scikit-learn identifed for import name sklearn
2021-11-18 15:21:02,036 [136924] INFO     thamos.lib: Package name python-dotenv identifed for import name dotenv
2021-11-18 15:21:02,053 [136924] INFO     thamos.lib: Adding 'scikit-learn' to default requirements of runtime environment 'ubi8'
2021-11-18 15:21:02,055 [136924] INFO     thamos.lib: Adding 'python-dotenv' to default requirements of runtime environment 'ubi8'
2021-11-18 15:21:02,057 [136924] WARNING  thamos.lib: Changes done might require triggering new advise to resolve dependencies
```

test.py has:
```
from sklearn.feature_extraction.text import CountVectorizer
from dotenv import load_dotenv

count_vect = CountVectorizer()
l = load_dotenv()
```

