### PR TITLE
Use dash instead of underscore in options

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1114,7 +1114,7 @@ def check(runtime_environment: Optional[str], output_format: str) -> None:  # no
     help="Operating system version filter.",
 )
 @click.option(
-    "--python_version",
+    "--python-version",
     "-p",
     type=str,
     default=None,


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

Unify option names across all the commands.
