### PR TITLE
Fix whatprovides output for Not Found Error

### DIFF
--- a/thamos/exceptions.py
+++ b/thamos/exceptions.py
@@ -72,3 +72,6 @@ class NoRequirementsFile(ThamosException):
 
 class NoDevRequirements(ThamosException):
     """An exception raised if no development requirements are found during the installation process."""
+
+class NoMatchingPackage(ThamosException):
+    """An exception raised if no matching package can be found for a given import."""

--- a/thamos/exceptions.py
+++ b/thamos/exceptions.py
@@ -73,5 +73,6 @@ class NoRequirementsFile(ThamosException):
 class NoDevRequirements(ThamosException):
     """An exception raised if no development requirements are found during the installation process."""
 
+
 class NoMatchingPackage(ThamosException):
     """An exception raised if no matching package can be found for a given import."""

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -69,6 +69,7 @@ from .exceptions import UnknownAnalysisType
 from .exceptions import TimeoutError
 from .exceptions import ApiError
 from .exceptions import NoDevRequirements
+from .exceptions import NoMatchingPackage
 from .exceptions import NoRequirementsFile
 
 from typing import Callable, Any, Union, Dict
@@ -1290,7 +1291,10 @@ def get_verified_packages_from_static_analysis(
             error_message = f"Failed to obtain package for import {import_name!r} (HTTP status {exc.status})\n"
 
             if exc.body:
-                error_message += str(json.loads(exc.body.decode("utf-8"))["error"])
+                try:
+                    error_message += str(json.loads(exc.body.decode("utf-8"))["error"])
+                except Exception as ex:
+                    raise ex
 
             if exc.status == 404:
                 _LOGGER.error("No matching package found for import %r", import_name)
@@ -1302,7 +1306,7 @@ def get_verified_packages_from_static_analysis(
                 exc.status,
                 exc.body,
             )
-            raise ApiError(error_message)
+            raise NoMatchingPackage(error_message)
 
         if imported_packages:
             for package in imported_packages:

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1287,31 +1287,12 @@ def get_verified_packages_from_static_analysis(
         try:
             imported_packages = get_package_from_imported_packages(import_name)
         except ApiException as exc:
-            error_message = "({0})\n Reason: {1}\n".format(exc.status, exc.reason)
 
-            if exc.headers:
-                error_message += "HTTP response headers: {0}\n".format(exc.headers)
-                headers_table = PrettyTable()
-                headers_table.field_names = ["Header field", "Value"]
-                headers_table.align = "l"
-
-                for header, value in dict(exc.headers).items():
-                    headers_table.add_row([header, value])
-
-                error_message += f"HTTP response headers: \n {str(headers_table)} \n"
-
+            print(
+                f"Failed to obtain package for import {import_name!r} (HTTP status {exc.status})\n"
+            )
             if exc.body:
-                error_message += "HTTP response body: {0}\n".format(exc.body)
-                body_table = PrettyTable()
-                body_table.field_names = ["Body field", "Value"]
-                body_table.align = "l"
-
-                for body, value in dict(json.loads(exc.body.decode("utf-8"))).items():
-                    body_table.add_row([body, value])
-
-                error_message += f"HTTP response body: \n {str(body_table)} \n"
-
-            print(error_message)
+                print(f"{exc.body['error']}")
 
             if exc.status == 404:
                 _LOGGER.error("No matching package found for import %r", import_name)

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1287,11 +1287,10 @@ def get_verified_packages_from_static_analysis(
             imported_packages = get_package_from_imported_packages(import_name)
         except ApiException as exc:
 
-            print(
-                f"Failed to obtain package for import {import_name!r} (HTTP status {exc.status})\n"
-            )
+            error_message = f"Failed to obtain package for import {import_name!r} (HTTP status {exc.status})\n"
+
             if exc.body:
-                print(f"{json.loads(exc.body.decode('utf-8'))['error']}")
+                error_message += str(json.loads(exc.body.decode("utf-8"))["error"])
 
             if exc.status == 404:
                 _LOGGER.error("No matching package found for import %r", import_name)
@@ -1303,7 +1302,7 @@ def get_verified_packages_from_static_analysis(
                 exc.status,
                 exc.body,
             )
-            continue
+            raise ApiError(error_message)
 
         if imported_packages:
             for package in imported_packages:

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -30,7 +30,6 @@ from time import monotonic
 from contextlib import contextmanager
 from functools import partial
 from functools import wraps
-from prettytable import PrettyTable
 import pprint
 import json
 import urllib3
@@ -1292,7 +1291,7 @@ def get_verified_packages_from_static_analysis(
                 f"Failed to obtain package for import {import_name!r} (HTTP status {exc.status})\n"
             )
             if exc.body:
-                print(f"{exc.body['error']}")
+                print(f"{json.loads(exc.body.decode('utf-8'))['error']}")
 
             if exc.status == 404:
                 _LOGGER.error("No matching package found for import %r", import_name)

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1288,13 +1288,13 @@ def get_verified_packages_from_static_analysis(
             imported_packages = get_package_from_imported_packages(import_name)
         except ApiException as exc:
 
-            error_message = f"Failed to obtain package for import {import_name!r} (HTTP status {exc.status})\n"
+            error_message = f"Failed to obtain package for import {import_name!r} (HTTP status {exc.status})"
 
             if exc.body:
                 try:
-                    error_message += str(json.loads(exc.body.decode("utf-8"))["error"])
+                    error_message += f": {str(json.loads(exc.body.decode('utf-8')['error']))}"
                 except Exception as ex:
-                    raise ex
+                    raise NoMatchingPackage(error_message) from ex
 
             if exc.status == 404:
                 _LOGGER.error("No matching package found for import %r", import_name)
@@ -1306,7 +1306,6 @@ def get_verified_packages_from_static_analysis(
                 exc.status,
                 exc.body,
             )
-            raise NoMatchingPackage(error_message)
 
         if imported_packages:
             for package in imported_packages:


### PR DESCRIPTION
## Related Issues and Dependencies

Related to #1005 

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Provide a more readable output for `NOT FOUND` error in `thamos whatprovides`
