### PR TITLE
Remove config_path property from configuration class

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -678,7 +678,7 @@ def advise(
     # In CLI we always call to obtain only the best software stack (count is implicitly set to 1).
     results = thoth_advise_here(
         recommendation_type=recommendation_type,
-        src_path=configuration.config_path,
+        src_path=".",
         runtime_environment_name=runtime_environment,
         debug=debug,
         nowait=no_wait,

--- a/thamos/config.py
+++ b/thamos/config.py
@@ -157,7 +157,6 @@ class _Configuration:
         self.explicit_host = None
         self.tls_verify = None
         self._api_url = None
-        self.config_path = None
 
     @property
     def api_url(self):
@@ -275,13 +274,11 @@ class _Configuration:
     def reset_config(self) -> None:
         """Discard loaded config in memory."""
         self._configuration = None
-        self.config_path = None
 
     def load_config(self, force: bool = False) -> None:
         """Load configuration from a file."""
         if not self._configuration and not force:
             with workdir(config.CONFIG_NAME):
-                self.config_path = os.getcwd()
                 self.load_config_from_file(config.CONFIG_NAME)
 
     def save_config(self, path: Optional[str] = None) -> None:

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -368,7 +368,7 @@ def advise_using_config(
     *,
     runtime_environment_name: typing.Optional[str] = None,
     constraints: typing.Optional[str] = None,
-    src_path: typing.Optional[str] = None,
+    src_path: str = ".",
     recommendation_type: str = None,
     dev: bool = False,
     no_static_analysis: bool = False,
@@ -398,7 +398,7 @@ def advise_using_config(
         pipfile_lock=pipfile_lock,
         constraints=constraints,
         recommendation_type=recommendation_type,
-        src_path=src_path if src_path is not None else thoth_config.config_path,
+        src_path=src_path,
         runtime_environment=thoth_config.get_runtime_environment(
             runtime_environment_name
         ),


### PR DESCRIPTION
## Related Issues and Dependencies

When asking for an advise considering also dev packages using `thamos advise --dev`, thamos fails with the following error:

```
2022-01-17 12:40:18,282 [1679651] CRITICAL root: Traceback (most recent call last):
  File "../thamos-cli", line 1599, in <module>
    __name__ == "__main__" and cli()
  File "/home/fpokorny/.local/share/virtualenvs/thamos-Sx0EJ786/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/fpokorny/.local/share/virtualenvs/thamos-Sx0EJ786/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/fpokorny/.local/share/virtualenvs/thamos-Sx0EJ786/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/fpokorny/.local/share/virtualenvs/thamos-Sx0EJ786/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/fpokorny/.local/share/virtualenvs/thamos-Sx0EJ786/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/fpokorny/.local/share/virtualenvs/thamos-Sx0EJ786/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "../thamos-cli", line 134, in wrapper
    return func(*args, **kwargs)
  File "../thamos-cli", line 679, in advise
    results = thoth_advise_here(
  File "/home/fpokorny/git/thoth-station/thamos/thamos/lib.py", line 704, in advise_here
    return advise(
  File "/home/fpokorny/git/thoth-station/thamos/thamos/lib.py", line 115, in wrapper
    result = func(api_client, *args, **kwargs)
  File "/home/fpokorny/git/thoth-station/thamos/thamos/lib.py", line 499, in advise
    library_usage = get_static_analysis(src_path)
  File "/home/fpokorny/git/thoth-station/thamos/thamos/lib.py", line 315, in get_static_analysis
    library_usage = gather_library_usage(
  File "/home/fpokorny/.local/share/virtualenvs/thamos-Sx0EJ786/lib/python3.8/site-packages/invectio/lib.py", line 387, in gather_library_usage
    for python_file, file_ast in _iter_python_file_ast(
  File "/home/fpokorny/.local/share/virtualenvs/thamos-Sx0EJ786/lib/python3.8/site-packages/invectio/lib.py", line 355, in _iter_python_file_ast
    for python_file in _get_python_files(path):
  File "/home/fpokorny/.local/share/virtualenvs/thamos-Sx0EJ786/lib/python3.8/site-packages/invectio/lib.py", line 340, in _get_python_files
    if os.path.isfile(path):
  File "/usr/lib/python3.8/genericpath.py", line 30, in isfile
    st = os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

The issue is in `config_path` property that is always assigned to None and updated only in some specific cases. We should drop this property as `workdir` can obtain information about the configuration file path.

## This introduces a breaking change

- [x] No

