### PR TITLE
Provide short help to fit terminal width

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1382,7 +1382,7 @@ def remove(
     configuration.save_project(project)
 
 
-@cli.command("support")
+@cli.command("support", short_help="Collect environment and configuration information.")
 @click.option(
     "--output",
     "-o",
@@ -1402,7 +1402,7 @@ def support(output: str) -> None:
             json.dump(info, output_file, sort_keys=True, indent=2)
 
 
-@cli.command("whatprovides")
+@cli.command("whatprovides", short_help="Check packages providing the given import.")
 @click.pass_context
 @click.option(
     "--output-format",
@@ -1445,7 +1445,7 @@ def whatprovides(import_name: str, output_format: str) -> None:  # noqa: D412
     sys.exit(0)
 
 
-@cli.command("discover")
+@cli.command("discover", short_help="Discover packages used in the project.")
 @click.pass_context
 @click.option(
     "--src-path",
@@ -1530,7 +1530,7 @@ def environments_(output_format: str) -> None:  # noqa: D412
         )
 
 
-@cli.command("verify")
+@cli.command("verify", short_help="Check lockfile freshness.")
 @click.pass_context
 @click.option(
     "--runtime-environment",


### PR DESCRIPTION
## Related Issues and Dependencies

Before:

```
thamos --help
Usage: thamos-cli [OPTIONS] COMMAND [ARGS]...

  CLI tool for interacting with Thoth.

Options:
  -v, --verbose          Be verbose about what's going on.
  -d, --workdir DIR      Adjust working directory for sub-commands.
  -t, --thoth-host HOST  Use selected host instead of the one stated in the
                         configuration file.
  --help                 Show this message and exit.

Commands:
  add               Add one or multiple requirements to the project.
  advise            Ask Thoth for recommendations on the application stack.
  check             Check the configuration file and runtime environment.
  config            Adjust Thamos and Thoth configuration.
  discover          Discover packages used in the project or in a file...
  environments      Show available Python environments.
  graph             Show dependency graph of resolved dependencies.
  images            Check available Thoth container images.
  indexes           List available Python package indexes.
  install           Install dependencies as stated in the lock file.
  list              List available runtime environments configured.
  log               Get log of running or finished analysis.
  provenance-check  Check provenance of installed packages.
  purge             Remove virtual environment created.
  remove            Remove the given requirement.
  run               Run the command in virtual environment.
  show              Show details for configured runtime environments.
  status            Get status of an analysis.
  support           Collect information from the current environment to...
  venv              Get path of the virtual environment.
  verify            Verify the hash in Pipfile.lock is up-to-date in...
  version           Print Thamos and Thoth version and exit.
  whatprovides      For a given import returns list of packages with...
```

After:

```
thamos --help
Usage: thamos-cli [OPTIONS] COMMAND [ARGS]...

  CLI tool for interacting with Thoth.

Options:
  -v, --verbose          Be verbose about what's going on.
  -d, --workdir DIR      Adjust working directory for sub-commands.
  -t, --thoth-host HOST  Use selected host instead of the one stated in the
                         configuration file.
  --help                 Show this message and exit.

Commands:
  add               Add one or multiple requirements to the project.
  advise            Ask Thoth for recommendations on the application stack.
  check             Check the configuration file and runtime environment.
  config            Adjust Thamos and Thoth configuration.
  discover          Discover packages used in the project.
  environments      Show available Python environments.
  graph             Show dependency graph of resolved dependencies.
  images            Check available Thoth container images.
  indexes           List available Python package indexes.
  install           Install dependencies as stated in the lock file.
  list              List available runtime environments configured.
  log               Get log of running or finished analysis.
  provenance-check  Check provenance of installed packages.
  purge             Remove virtual environment created.
  remove            Remove the given requirement.
  run               Run the command in virtual environment.
  show              Show details for configured runtime environments.
  status            Get status of an analysis.
  support           Collect environment and configuration information.
  venv              Get path of the virtual environment.
  verify            Check lockfile freshness.
  version           Print Thamos and Thoth version and exit.
  whatprovides      Check packages providing the given import.
```
## This introduces a breaking change

- [x] No
