### PR TITLE
Fix thamos venv not printing virtualenv path

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -524,6 +524,8 @@ def venv(ctx, runtime_environment: Optional[str] = None) -> None:
     else:
         _error_virtual_environment(virtualenv_path)
 
+    click.echo(virtualenv_path)
+
 
 @cli.command("purge")
 @click.pass_context


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #1060 

## This introduces a breaking change

- [x] No
