### PR TITLE
Add link to container image analyses from Thoth Search UI in thamos images

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -129,8 +129,6 @@ _REPORT_TRANSLATION_TABLE_ENVIRONMENTS = {
     "python_version": "Python version",
 }
 
-THOTH_SEARCH_UI_BASE_URL = configuration.thoth_search_ui_url
-
 
 def handle_cli_exception(func: typing.Callable) -> typing.Callable:
     """Suppress exception in CLI if debug mode was not turned on."""
@@ -1368,7 +1366,7 @@ def images(
             for key, value in item.items():
                 if key == "package_extract_document_id":
                     container_image_search_link = (
-                        f"{THOTH_SEARCH_UI_BASE_URL}image/{value}"
+                        f"{configuration.thoth_search_ui_url}image/{value}"
                     )
                 key = _REPORT_TRANSLATION_TABLE_IMAGES.get(
                     key, key.replace("_", " ").capitalize()

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -20,7 +20,6 @@
 import json
 import logging
 import os
-import requests
 import shutil
 import subprocess
 import sys
@@ -130,9 +129,7 @@ _REPORT_TRANSLATION_TABLE_ENVIRONMENTS = {
     "python_version": "Python version",
 }
 
-THOTH_SEARCH_UI_BASE_URL = requests.get(configuration.api_url).headers[
-    "X-Thoth-Search-Ui-Url"
-]
+THOTH_SEARCH_UI_BASE_URL = configuration.thoth_search_ui_url
 
 
 def handle_cli_exception(func: typing.Callable) -> typing.Callable:

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1363,11 +1363,13 @@ def images(
     elif output_format == "table":
         for item in result:
             table_content = []
+            container_image_search_link = ""
             for key, value in item.items():
-                if key == "package_extract_document_id":
-                    container_image_search_link = (
-                        f"{configuration.thoth_search_ui_url}image/{value}"
-                    )
+                if configuration.thoth_search_ui_url is not None:
+                    if key == "package_extract_document_id":
+                        container_image_search_link = (
+                            f"{configuration.thoth_search_ui_url}image/{value}"
+                        )
                 key = _REPORT_TRANSLATION_TABLE_IMAGES.get(
                     key, key.replace("_", " ").capitalize()
                 )
@@ -1375,16 +1377,18 @@ def images(
                 # Here, key value are ignored. This is a trick to have "table header" as the first column.
                 table_content.extend([{"key": key, "value": value}])
 
-            table_content.extend(
-                [
-                    {
-                        "key": Text.from_markup(
-                            "See more details in Thoth Search UI:", style="bold cyan"
-                        ),
-                        "value": container_image_search_link,
-                    }
-                ]
-            )
+            if container_image_search_link != "":
+                table_content.extend(
+                    [
+                        {
+                            "key": Text.from_markup(
+                                "See more details in Thoth Search UI:",
+                                style="bold cyan",
+                            ),
+                            "value": container_image_search_link,
+                        }
+                    ]
+                )
             _print_report(
                 table_content,
                 title=f"Container image {item.get('environment_name', 'UNKNOWN')}",

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -20,6 +20,7 @@
 import json
 import logging
 import os
+import requests
 import shutil
 import subprocess
 import sys
@@ -129,9 +130,9 @@ _REPORT_TRANSLATION_TABLE_ENVIRONMENTS = {
     "python_version": "Python version",
 }
 
-THOTH_SEARCH_UI_BASE_URL = os.getenv(
-    "THOTH_SEARCH_UI_URL", "https://thoth-station.ninja/search/"
-)
+THOTH_SEARCH_UI_BASE_URL = requests.get(configuration.api_url).headers[
+    "X-Thoth-Search-Ui-Url"
+]
 
 
 def handle_cli_exception(func: typing.Callable) -> typing.Callable:

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -129,6 +129,8 @@ _REPORT_TRANSLATION_TABLE_ENVIRONMENTS = {
     "python_version": "Python version",
 }
 
+_THOTH_SEARCH_BASE_URL = "https://thoth-station.ninja/search/"
+
 
 def handle_cli_exception(func: typing.Callable) -> typing.Callable:
     """Suppress exception in CLI if debug mode was not turned on."""
@@ -1367,10 +1369,24 @@ def images(
                 key = _REPORT_TRANSLATION_TABLE_IMAGES.get(
                     key, key.replace("_", " ").capitalize()
                 )
+                if key == "Container image analysis":
+                    container_image_search_link = (
+                        f"{_THOTH_SEARCH_BASE_URL}image/{value}"
+                    )
                 key = Text.from_markup(key, style="green bold")
                 # Here, key value are ignored. This is a trick to have "table header" as the first column.
                 table_content.extend([{"key": key, "value": value}])
 
+            table_content.extend(
+                [
+                    {
+                        "key": Text.from_markup(
+                            "See more details in Thoth Search UI:", style="bold cyan"
+                        ),
+                        "value": container_image_search_link,
+                    }
+                ]
+            )
             _print_report(
                 table_content,
                 title=f"Container image {item.get('environment_name', 'UNKNOWN')}",

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -129,7 +129,9 @@ _REPORT_TRANSLATION_TABLE_ENVIRONMENTS = {
     "python_version": "Python version",
 }
 
-_THOTH_SEARCH_BASE_URL = "https://thoth-station.ninja/search/"
+THOTH_SEARCH_UI_BASE_URL = os.getenv(
+    "THOTH_SEARCH_UI_URL", "https://thoth-station.ninja/search/"
+)
 
 
 def handle_cli_exception(func: typing.Callable) -> typing.Callable:
@@ -1366,13 +1368,13 @@ def images(
         for item in result:
             table_content = []
             for key, value in item.items():
+                if key == "package_extract_document_id":
+                    container_image_search_link = (
+                        f"{THOTH_SEARCH_UI_BASE_URL}image/{value}"
+                    )
                 key = _REPORT_TRANSLATION_TABLE_IMAGES.get(
                     key, key.replace("_", " ").capitalize()
                 )
-                if key == "Container image analysis":
-                    container_image_search_link = (
-                        f"{_THOTH_SEARCH_BASE_URL}image/{value}"
-                    )
                 key = Text.from_markup(key, style="green bold")
                 # Here, key value are ignored. This is a trick to have "table header" as the first column.
                 table_content.extend([{"key": key, "value": value}])

--- a/thamos/config.py
+++ b/thamos/config.py
@@ -25,6 +25,7 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import List
+from typing import Tuple
 from urllib.parse import urljoin
 from jsonschema import validate
 
@@ -163,9 +164,16 @@ class _Configuration:
     def api_url(self):
         """Get URL to Thoth's API."""
         if not self._api_url:
-            self._api_url = self.api_discovery(self.content["host"])
+            self._api_url = self.api_discovery(self.content["host"])[0]
 
         return self._api_url
+
+    @property
+    def thoth_search_ui_url(self):
+        if not self._thoth_search_ui_url:
+            self._thoth_search_ui_url = self.api_discovery(self.content["host"])[1]
+
+        return self._thoth_search_ui_url
 
     @property
     def content(self):
@@ -463,7 +471,7 @@ class _Configuration:
 
         return to_return
 
-    def api_discovery(self, host: str) -> str:
+    def api_discovery(self, host: str) -> Tuple[str, str]:
         """Discover API versions available, return the most recent one supported by client and server."""
         api_url = urljoin("https://" + host, "api/v1")
         self.tls_verify = (
@@ -487,6 +495,8 @@ class _Configuration:
             api_url, verify=self.tls_verify, headers={"Accept": "application/json"}
         )
 
+        thoth_search_ui_url = response.headers["X-Thoth-Search-Ui-Url"]
+
         try:
             response.raise_for_status()
         except Exception as exc:
@@ -499,7 +509,7 @@ class _Configuration:
             ) from exc
 
         self._api_url = api_url
-        return self._api_url
+        return self._api_url, thoth_search_ui_url
 
     def check_runtime_environment(
         self, runtime_environment_name: str

--- a/thamos/config.py
+++ b/thamos/config.py
@@ -495,7 +495,7 @@ class _Configuration:
             api_url, verify=self.tls_verify, headers={"Accept": "application/json"}
         )
 
-        self._thoth_search_ui_url = response.headers["X-Thoth-Search-Ui-Url"]
+        self._thoth_search_ui_url = response.headers.get("X-Thoth-Search-Ui-Url")
 
         try:
             response.raise_for_status()

--- a/thamos/config.py
+++ b/thamos/config.py
@@ -158,6 +158,7 @@ class _Configuration:
         self.explicit_host = None
         self.tls_verify = None
         self._api_url = None
+        self._thoth_search_ui_url = None
 
     @property
     def api_url(self):

--- a/thamos/config.py
+++ b/thamos/config.py
@@ -25,7 +25,6 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import List
-from typing import Tuple
 from urllib.parse import urljoin
 from jsonschema import validate
 
@@ -164,14 +163,14 @@ class _Configuration:
     def api_url(self):
         """Get URL to Thoth's API."""
         if not self._api_url:
-            self._api_url = self.api_discovery(self.content["host"])[0]
+            self._api_url = self.api_discovery(self.content["host"])
 
         return self._api_url
 
     @property
     def thoth_search_ui_url(self):
         if not self._thoth_search_ui_url:
-            self._thoth_search_ui_url = self.api_discovery(self.content["host"])[1]
+            self.api_discovery(self.content["host"])
 
         return self._thoth_search_ui_url
 
@@ -471,7 +470,7 @@ class _Configuration:
 
         return to_return
 
-    def api_discovery(self, host: str) -> Tuple[str, str]:
+    def api_discovery(self, host: str) -> str:
         """Discover API versions available, return the most recent one supported by client and server."""
         api_url = urljoin("https://" + host, "api/v1")
         self.tls_verify = (
@@ -495,7 +494,7 @@ class _Configuration:
             api_url, verify=self.tls_verify, headers={"Accept": "application/json"}
         )
 
-        thoth_search_ui_url = response.headers["X-Thoth-Search-Ui-Url"]
+        self._thoth_search_ui_url = response.headers["X-Thoth-Search-Ui-Url"]
 
         try:
             response.raise_for_status()
@@ -509,7 +508,7 @@ class _Configuration:
             ) from exc
 
         self._api_url = api_url
-        return self._api_url, thoth_search_ui_url
+        return self._api_url
 
     def check_runtime_environment(
         self, runtime_environment_name: str


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/thamos/issues/1080

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Add a link to the image analyses present in Thoth Search UI for images listed by the `thamos images` command.

![Screenshot from 2022-03-15 17-24-14](https://user-images.githubusercontent.com/66788861/158425280-a4b68a94-7322-4191-8e09-c451628a87e5.png)

