### PR TITLE
Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,24 +1,27 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: "kind/bug, needs-triage"
+labels: kind/bug
 ---
+## Bug description
+<!-- A clear and concise description of what the bug is. -->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
+### Steps to Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Actual behavior
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Additional context**
-Add any other context about the problem here.
+### Environment information
+<!-- Please include names and versions of the components involved.
+If appropriate, include relevant parts of their configuration. -->
+
+### Additional context
+<!-- Add any additional context information about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,31 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: "kind/feature, needs-triage"
+labels: kind/feature
 ---
+## Problem statement
+<!-- Is your feature request related to a problem? Please provide a clear and concise description of what the problem is.
+Ex. I'm always frustrated when [...]
+This should be a user story! -->
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## High-level Goals
+<!-- list of high-level Acceptance Criteria/Goals (that is signed off by the team, and unchangeable) -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+## Proposal description
+<!-- Describe the solution you'd like.
+A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Alternatives
+<!-- Describe alternatives you've considered.
+A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->
+
+## Acceptance Criteria
+<!-- checklist of detailed Acceptance Criteria (that might extend over the lifetime of the card).
+Use checkboxes to track each item. -->
+
+- [ ] example
+
+<!-- If applicable add a measure of complexity (story points)/time estimate to the title using [...pt] -->

--- a/.github/ISSUE_TEMPLATE/kebechet_update.md
+++ b/.github/ISSUE_TEMPLATE/kebechet_update.md
@@ -1,10 +1,7 @@
 ---
-name: Kebechet update
-about: Manually trigger update of dependencies
+name: Update dependencies
+about: Check Pipfiles and update dependencies
 title: Kebechet update
-labels: bot
+assignees: sesheta
+labels: "bot, priority/critical-urgent"
 ---
-
-Hey, Kebechet!
-
-Update my dependencies, please.

--- a/.github/ISSUE_TEMPLATE/major-release.md
+++ b/.github/ISSUE_TEMPLATE/major-release.md
@@ -9,3 +9,10 @@ labels: "bot, priority/critical-urgent"
 Hey, Kebechet!
 
 Create a new major release, please.
+
+
+**IMPORTANT NOTES**
+
+- _If [Khebut GitHub App Bot](https://github.com/apps/khebhut) is installed, this issue will trigger a major release. The bot will open a Pull Request to update the CHANGELOG, fix the opened issue and create a tag._
+
+- _Only users that are allowed to release (a.k.a. maintainers specified in the .thoth.yaml file) can open the issue, otherwise bot will reject them, commenting and closing the issue. If [AICoE CI GitHub App](https://github.com/apps/aicoe-ci) is installed, once the pull request is merged and a new tag is created by the bot, the pipeline to build and push image starts._

--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -9,3 +9,9 @@ labels: "bot, priority/critical-urgent"
 Hey, Kebechet!
 
 Create a new minor release, please.
+
+**IMPORTANT NOTES**
+
+- _If [Khebut GitHub App Bot](https://github.com/apps/khebhut) is installed, this issue will trigger a minor release. The bot will open a Pull Request to update the CHANGELOG, fix the opened issue and create a tag._
+
+- _Only users that are allowed to release (a.k.a. maintainers specified in the .thoth.yaml file) can open the issue, otherwise bot will reject them, commenting and closing the issue. If [AICoE CI GitHub App](https://github.com/apps/aicoe-ci) is installed, once the pull request is merged and a new tag is created by the bot, the pipeline to build and push image starts._

--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -9,3 +9,9 @@ labels: "bot, priority/critical-urgent"
 Hey, Kebechet!
 
 Create a new patch release, please.
+
+**IMPORTANT NOTES**
+
+- _If [Khebut GitHub App Bot](https://github.com/apps/khebhut) is installed, this issue will trigger a patch release. The bot will open a Pull Request to update the CHANGELOG, fix the opened issue and create a tag._
+
+- _Only users that are allowed to release (a.k.a. maintainers specified in the .thoth.yaml file) can open the issue, otherwise bot will reject them, commenting and closing the issue. If [AICoE CI GitHub App](https://github.com/apps/aicoe-ci) is installed, once the pull request is merged and a new tag is created by the bot, the pipeline to build and push image starts._

--- a/.github/ISSUE_TEMPLATE/redeliver_container_image.md
+++ b/.github/ISSUE_TEMPLATE/redeliver_container_image.md
@@ -11,3 +11,8 @@ Hey, AICoE-CI!
 Please build and deliver the following git tag:
 
 Tag: x.y.z
+
+
+**IMPORTANT NOTES**
+
+- _If the tag exists and [AICoE CI GitHub App](https://github.com/apps/aicoe-ci) is installed, this issue will retrigger the pipeline to build from tag and push image container image. It should be used if the pipeline triggered with the {major|minor|patch} release failed for any reason._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,25 @@
 ## Related Issues and Dependencies
-
-…
+<!-- Mention any relevant issue/PR here.
+In particular, if this PR resolves issue XYZ, make sure you add a line:
+Fixes: #XYZ -->
 
 ## This introduces a breaking change
+<!-- Leave one of the options -->
 
-- [ ] Yes
-- [ ] No
+- Yes
+- No
 
 <!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
 
 ## This should yield a new module release
 
-- [ ] Yes
-- [ ] No
+- Yes
+- No
+
+<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->
 
 ## This Pull Request implements
+<!-- Provide a summary of your changes here. -->
 
-… Explain your changes.
-
-## Description
-
-<!--- Describe your changes in detail -->
+### Description
+<!--- Describe your changes in detail here. -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 exclude: "thamos/swagger_client/|docs/|Documentation"
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+    rev: v1.1.13
     hooks:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.1.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -25,26 +25,19 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pycqa/pydocstyle.git
-    rev: 5.1.1
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
         exclude: "thamos/swagger_client/|docs/"
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
-    hooks:
-      - id: check-toml
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
       - id: black
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
       - id: flake8
         additional_dependencies: ["pep8-naming"]
@@ -54,6 +47,6 @@ repos:
         exclude: "^(thamos/swagger_client/|examples/|docs/)"
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.46"
+    rev: "0.48"
     hooks:
       - id: check-manifest


### PR DESCRIPTION
## Related Issues and Dependencies

The trigger for this is that the `needs-triage` label is no longer in widespread use (see https://github.com/thoth-station/thoth-application/issues/2359)
but the templates are still adding it to new issues in this repo (see e.g. #1082).

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Update the GitHub issue and PR templates taking the current content from the [template project repo](https://github.com/thoth-station/template-project/tree/master/.github)

Also taking the opportunity to update pre-commit versions.