### PR TITLE
Fix python version display in support command

### DIFF
--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1512,7 +1512,7 @@ def collect_support_information_dict() -> Dict[str, Any]:
         "platform_system": platform.system(),
         "platform_version": platform.version(),
         "python_full_version": platform.python_version(),
-        "python_version": platform.python_version()[:3],
+        "python_version": ".".join(platform.python_version().split(".")[:-1]),
         "sys_platform": sys.platform,
         "pip_freeze": pip_freeze,
         "discovery": discovery,

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1512,7 +1512,7 @@ def collect_support_information_dict() -> Dict[str, Any]:
         "platform_system": platform.system(),
         "platform_version": platform.version(),
         "python_full_version": platform.python_version(),
-        "python_version": ".".join(platform.python_version().split(".")[:-1]),
+        "python_version": ".".join(platform.python_version().split(".")[:2]),
         "sys_platform": sys.platform,
         "pip_freeze": pip_freeze,
         "discovery": discovery,


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes #1085 

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements
Fix the output of python version for the `support` command to keep the major and minor release numbers regardless of minor release number length.
