### PR TITLE
Fix key error for `thamos graph` when no --dev flag was supplied

### DIFF
--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -1601,9 +1601,17 @@ def print_dependency_graph_from_adviser_document(
     pipfile_lock = adviser_document["report"]["products"][0]["project"][
         "requirements_locked"
     ]
-    for direct_dependency in chain(
-        pipfile["packages"].keys(), pipfile["dev-packages"].keys()
-    ):
+
+    direct_dependencies = pipfile["packages"].keys()
+    if adviser_document["parameters"]["dev"]:
+        # Include dev packages in the listing only if dev flag was supplied
+        direct_dependencies = chain(direct_dependencies, pipfile["dev-packages"].keys())
+    else:
+        _LOGGER.warning(
+            "Development dependencies will not be shown as no --dev flag was supplied to the resolution process"
+        )
+
+    for direct_dependency in direct_dependencies:
         direct_dependency_idx = nodes_idx[direct_dependency]
         print(f"→ {_get_package_entry_str(pipfile_lock, direct_dependency)}")
         _traverse_edges(


### PR DESCRIPTION
## This should yield a new module release

- No

### Description


```
2022-03-23 10:46:11,780 [3249561] CRITICAL root: Traceback (most recent call last):
  File "/home/fpokorny/.local/bin/thamos", line 8, in <module>
    sys.exit(cli())
  File "/home/fpokorny/.local/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/fpokorny/.local/lib/python3.8/site-packages/rich_click/rich_click.py", line 594, in main
    return super().main(*args, standalone_mode=False, **kwargs)
  File "/home/fpokorny/.local/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/fpokorny/.local/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/fpokorny/.local/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/fpokorny/.local/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/fpokorny/.local/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/fpokorny/.local/lib/python3.8/site-packages/thamos/cli.py", line 139, in wrapper
    return func(*args, **kwargs)
  File "/home/fpokorny/.local/lib/python3.8/site-packages/thamos/cli.py", line 1052, in graph
    printed = print_dependency_graph(analysis_id, fold=fold)
  File "/home/fpokorny/.local/lib/python3.8/site-packages/thamos/lib.py", line 1637, in print_dependency_graph
    return print_dependency_graph_from_adviser_document(adviser_document, fold=fold)
  File "/home/fpokorny/.local/lib/python3.8/site-packages/thamos/lib.py", line 1607, in print_dependency_graph_from_adviser_document
    direct_dependency_idx = nodes_idx[direct_dependency]
KeyError: 'pytest'
```
