### PR TITLE
Modify label parsing logic to allow list of values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ resolver will include pipeline units that match labels with the ones provided
 on the request.
 
 An example can be a CI system that is asking for an advise and labels the
-request with ``requester=ci_foo,team=thoth``. In such a case, the resolution
+request with ``requester=ci_foo;team=thoth``. In such a case, the resolution
 engine includes pipeline units that are specific to the CI system and the team
 specified (besides the ones that are added by default). Labels can be specified
 in the ``.thoth.yaml`` configuration file or using CLI (labels passed via CLI
@@ -172,7 +172,7 @@ take precedence):
 
 .. code-block:: console
 
-  thamos advise --labels requester=ci_foo,team=thoth
+  thamos advise --labels requester=ci_foo;team=thoth
 
 See the following `demo for more information
 <https://www.youtube.com/watch?v=eoJIfQip_6M>`__.

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -214,7 +214,7 @@ def _parse_labels(label: Optional[str]) -> Optional[Dict[str, str]]:
         return None
 
     labels: Dict[str, str] = {}
-    parts = label.split(",")
+    parts = label.split(";")
     for part in parts:
         lab = part.split("=")
         if len(lab) != 2:
@@ -684,7 +684,7 @@ def purge(
     "-l",
     envvar="THAMOS_LABELS",
     type=str,
-    metavar="KEY1=VALUE1,KEY2=VALUE2",
+    metavar="KEY1=VALUE1;KEY2=VALUE2,VALUE3",
     default=None,
     show_default=True,
     help="Labels used to label the request.",
@@ -715,7 +715,7 @@ def advise(
     [bold yellow]Examples:[/bold yellow]
     [purple]
 
-      thamos advise --runtime-environment testing --labels 'foo=bar,qux=baz'
+      thamos advise --runtime-environment testing --labels 'foo=bar;qux=baz,bap'
 
       thamos advise --dev
 


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #1120 

## This introduces a breaking change

- Yes

## This should yield a new module release

- Yes

## This Pull Request implements

Modify the label parsing logic to allow lists as label values (ex: `allow-cve=PYSEC-2021-94,PYSEC-2021-2`).
Different labels should now be specified using a semicolon instead of a coma, as this separator will be used to separate elements of a single label value.
