### PR TITLE
Extend and unit test thamos discover

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: "thamos/swagger_client/|docs/|Documentation"
+exclude: "thamos/swagger_client/|docs/|Documentation|tests/data/cpu_info_file"
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.3.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include thamos-cli
 include requirements.txt
 include requirements-test.txt
 include thamos/data/defaultThoth.yaml
+include tests/data/cpu_info_file
 include *.json
 include *.lock
 include *.md

--- a/tests/data/cpu_info_file
+++ b/tests/data/cpu_info_file
@@ -1,0 +1,215 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 142
+model name	: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+stepping	: 12
+microcode	: 0xea
+cpu MHz		: 2099.999
+cache size	: 8192 KB
+physical id	: 0
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit srbds
+bogomips	: 4608.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 142
+model name	: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+stepping	: 12
+microcode	: 0xea
+cpu MHz		: 2100.000
+cache size	: 8192 KB
+physical id	: 0
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit srbds
+bogomips	: 4608.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 142
+model name	: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+stepping	: 12
+microcode	: 0xea
+cpu MHz		: 2099.999
+cache size	: 8192 KB
+physical id	: 0
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 4
+initial apicid	: 4
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit srbds
+bogomips	: 4608.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 142
+model name	: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+stepping	: 12
+microcode	: 0xea
+cpu MHz		: 2100.000
+cache size	: 8192 KB
+physical id	: 0
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 6
+initial apicid	: 6
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit srbds
+bogomips	: 4608.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 4
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 142
+model name	: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+stepping	: 12
+microcode	: 0xea
+cpu MHz		: 2100.000
+cache size	: 8192 KB
+physical id	: 0
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit srbds
+bogomips	: 4608.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 5
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 142
+model name	: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+stepping	: 12
+microcode	: 0xea
+cpu MHz		: 2100.001
+cache size	: 8192 KB
+physical id	: 0
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit srbds
+bogomips	: 4608.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 6
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 142
+model name	: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+stepping	: 12
+microcode	: 0xea
+cpu MHz		: 2100.000
+cache size	: 8192 KB
+physical id	: 0
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 5
+initial apicid	: 5
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit srbds
+bogomips	: 4608.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 7
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 142
+model name	: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+stepping	: 12
+microcode	: 0xea
+cpu MHz		: 2099.999
+cache size	: 8192 KB
+physical id	: 0
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 7
+initial apicid	: 7
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit srbds
+bogomips	: 4608.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# thamos
+# Copyright(C) 2022 Maya Costantini
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Tests for the thamos discover command implementation."""
+
+import mock
+
+from thoth.analyzer import CommandResult
+from thoth.analyzer import run_command
+from thamos import discover
+
+from base import ThamosTestCase
+
+
+_CUDA_VERSION_OUTPUT = '"nvcc: NVIDIA (R) Cuda compiler driver\n Copyright (c) 2005-2015 NVIDIA Corporation\n Built on Mon_Feb_16_22:59:02_CST_2015\n Cuda compilation tools, release 7.0, V7.0.27"'  # noqa
+_CUDNN_HEADERS_OUTPUT = '"#define CUDNN_MAJOR 7\n #define CUDNN_MINOR 5\n #define CUDNN_PATCHLEVEL 0\n #define CUDNN_VERSION (CUDNN_MAJOR * 1000 + CUDNN_MINOR * 100 + CUDNN_PATCHLEVEL)"'  # noqa
+_OPENBLAS_RPM_OUTPUT = (
+    '"openblas-0.3.15-3.el8.x86_64\n openblas-srpm-macros-2-2.el8.noarch"'
+)
+_OPENMPI_RPM_OUTPUT = '"openmpi-devel-4.1.1-3.el8.x86_64\n openmpi-4.1.1-3.el8.x86_64"'
+_MKL_PIPY_OUTPUT = '"mkl                               2022.1.0"'
+_LSPCI_OUTPUT = '"00:02.0 VGA compatible controller: Intel Corporation CometLake-U GT2 [UHD Graphics] (rev 02)"'
+
+
+def _mock_run_command_available(*args, **kwargs) -> CommandResult:
+    """Mock run_command when information is available."""
+    if args[0] == "nvcc --version":
+        return run_command(f"echo {_CUDA_VERSION_OUTPUT}")
+
+    if args[0].endswith("grep CUDNN_MAJOR -A 10"):
+        return run_command(f"echo {_CUDNN_HEADERS_OUTPUT}")
+
+    if args[0] == "pip list | grep -F mkl":
+        return run_command(f"echo {_MKL_PIPY_OUTPUT}")
+
+    if args[0] == "rpm -qa | grep openblas":
+        return run_command(f"echo {_OPENBLAS_RPM_OUTPUT}")
+
+    if args[0] == "rpm -qa | grep openmpi":
+        return run_command(f"echo {_OPENMPI_RPM_OUTPUT}")
+
+    if args[0] == "lspci | grep VGA":
+        return run_command(f"echo {_LSPCI_OUTPUT}")
+
+
+def _mock_run_command_not_found(*args, **kwargs) -> CommandResult:
+    """Mock run_command when information is not found."""
+    if args[0] == "nvcc --version":
+        return run_command("exit 127", raise_on_error=False)
+
+    if args[0].endswith("grep CUDNN_MAJOR -A 10"):
+        return run_command("exit 1", raise_on_error=False)
+
+    if args[0] == "pip list | grep -F mkl":
+        return run_command("exit 1", raise_on_error=False)
+
+    if args[0] == "rpm -qa | grep openblas":
+        return run_command("exit 1", raise_on_error=False)
+
+    if args[0] == "rpm -qa | grep openmpi":
+        return run_command("exit 1", raise_on_error=False)
+
+    if args[0] == "lspci | grep VGA":
+        return run_command("exit 1", raise_on_error=False)
+
+
+class TestDiscover(ThamosTestCase):
+    """Tests for the thamos discover command."""
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_available)
+    def test_discover_cuda_version_present(self) -> None:
+        """Test discovering CUDA version if present in environment."""
+        with mock.patch("thamos.discover.run_command", new=_mock_run_command_available):
+            with mock.patch("os.environ", {"THAMOS_DISABLE_CUDA": "0"}):
+                assert discover.discover_cuda_version() == "7.0"
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_not_found)
+    def test_discover_cuda_version_not_present(self):
+        """Test discovering CUDS version if not present in environment."""
+        with mock.patch("os.environ", {"THAMOS_DISABLE_CUDA": "1"}):
+            assert discover.discover_cuda_version() is None
+
+    def test_discover_distribution(self) -> None:
+        """Test discovering distribution."""
+        with mock.patch("distro.linux_distribution") as mock_distribution:
+            mock_distribution.return_value = ("rhel", "8.5", "Ootpa")
+            assert discover.discover_distribution() == ("rhel", "8")
+
+    def test_discover_python_version(self) -> None:
+        """Test discovering Python version."""
+        with mock.patch("sys.version_info") as mock_sys_version_info:
+            mock_sys_version_info.major, mock_sys_version_info.minor = "3", "8"
+            assert discover.discover_python_version() == "3.8"
+
+            mock_sys_version_info.major, mock_sys_version_info.minor = "3", "10"
+            assert discover.discover_python_version() == "3.10"
+
+    def test_discover_cpu(self) -> None:
+        """Test discovering CPU."""
+        test_cpu_info_correct = {
+            "cpu_family": 6,
+            "cpu_model": 142,
+            "cpu_model_name": "Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz",
+        }
+
+        test_cpu_info_wrong = {
+            "cpu_family": 7,
+            "cpu_model": 142,
+            "cpu_model_name": "Intel(R) Core(TM) i7-10610U CPU @ 1.60GHz",
+        }
+
+        with mock.patch("thamos.discover._PROC_CPU_INFO", "tests/data/cpu_info_file"):
+            assert discover.discover_cpu() == test_cpu_info_correct
+            assert discover.discover_cpu() != test_cpu_info_wrong
+
+    def test_discover_platform(self) -> None:
+        """Test discover platform."""
+        with mock.patch("sysconfig.get_platform") as mock_get_platform:
+            mock_get_platform.return_value = "linux-x86_64"
+            assert discover.discover_platform() == "linux-x86_64"
+
+    def test_discover_base_image(self) -> None:
+        """Test discovering base image."""
+
+        def getenv_image(env_variable: str, *args) -> str:
+            mock_env = {
+                "IMAGE_NAME": "s2i-thoth-ubi8-py38",
+                "THOTH_S2I_NAME": "quay.io/thoth-station/s2i-thoth-ubi8-py38",
+                "THOTH_S2I_VERSION": "0.33.0",
+                "IMAGE_TAG": "0.33.0",
+            }
+            return mock_env.get(env_variable)
+
+        with mock.patch("os.getenv", side_effect=getenv_image):
+            assert discover.discover_base_image() == "s2i-thoth-ubi8-py38:0.33.0"
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_available)
+    def test_discover_cudnn_version_available(self) -> None:
+        """Test discover CuDNN version when present in environment."""
+        assert discover.discover_cudnn_version() == "7.5.0"
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_not_found)
+    def test_discover_cudnn_version_not_found(self) -> None:
+        """Test discover CuDNN version when not present in environment."""
+        assert discover.discover_cudnn_version() is None
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_available)
+    def test_discover_mkl_available(self) -> None:
+        """Test discover MKL Python package version when present in environment."""
+        assert discover.discover_mkl_version() == "2022.1.0"
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_not_found)
+    def test_discover_mkl_not_found(self) -> None:
+        """Test discover MKL Python package version when not present in environment."""
+        assert discover.discover_mkl_version() is None
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_available)
+    def test_discover_openblas_available(self) -> None:
+        """Test discover OpenBLAS as an RPM package when present in environment."""
+        assert discover.discover_rpm_package("openblas") == {
+            "name": "openblas",
+            "version": "0.3.15",
+            "release": "3.el8",
+            "epoch": "",
+            "architecture": "x86_64",
+        }
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_not_found)
+    def test_discover_openblas_not_found(self) -> None:
+        """Test discover OpenBLAS as an RPM package when not present in environment."""
+        assert discover.discover_rpm_package("openblas") is None
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_available)
+    def test_discover_openmpi_available(self) -> None:
+        """Test discover OpenMPI as an RPM package when present in environment."""
+        assert discover.discover_rpm_package("openmpi") == {
+            "name": "openmpi",
+            "version": "4.1.1",
+            "release": "3.el8",
+            "epoch": "",
+            "architecture": "x86_64",
+        }
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_not_found)
+    def test_discover_openmpi_not_found(self) -> None:
+        """Test discover OpenMPI as an RPM package when not present in environment."""
+        assert discover.discover_rpm_package("openmpi") is None
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_available)
+    def test_discover_gpu_model_available(self) -> None:
+        """Test discover GPU model when present in environment."""
+        assert (
+            discover.discover_gpu_model()
+            == "VGA compatible controller: Intel Corporation CometLake-U GT2 [UHD Graphics] (rev 02)"
+        )
+
+    @mock.patch("thamos.discover.run_command", new=_mock_run_command_not_found)
+    def test_discover_gpu_model_not_found(self) -> None:
+        """Test discover GPU model when not present in environment."""
+        assert discover.discover_gpu_model() is None

--- a/thamos/discover.py
+++ b/thamos/discover.py
@@ -17,33 +17,71 @@
 
 """Implementation discovery methods to detect the current environment and its configuration."""
 
+import click
+import distro
 import os
 import sys
 import logging
-import typing
 import sysconfig
 
-from typing import Dict, Union
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Union
 
+from thoth.analyzer import run_command
 from thoth.common import map_os_name
 from thoth.common import normalize_os_version
 
-import distro
-import click
-from thoth.analyzer import run_command
 
 _LOGGER = logging.getLogger(__name__)
 _PROC_CPU_INFO = "/proc/cpuinfo"
 
 
-def discover_cuda_version(interactive: bool = False) -> typing.Optional[str]:
+# Taken from https://github.com/rpm-software-management/yum/blob/master/rpmUtils/miscutils.py as rpmUtils was deprecated
+def _split_rpm_filename(filename):
+    """
+    Pass in a standard style rpm fullname.
+
+    Return a name, version, release, epoch, arch, e.g.::
+        foo-1.0-1.i386.rpm returns foo, 1.0, 1, i386
+        1:bar-9-123a.ia64.rpm returns bar, 9, 123a, 1, ia64
+    """
+    if filename[-4:] == ".rpm":
+        filename = filename[:-4]
+
+    arch_index = filename.rfind(".")
+    arch = filename[arch_index + 1 :]
+
+    rel_index = filename[:arch_index].rfind("-")
+    rel = filename[rel_index + 1 : arch_index]
+
+    ver_index = filename[:rel_index].rfind("-")
+    ver = filename[ver_index + 1 : rel_index]
+
+    epoch_index = filename.find(":")
+    if epoch_index == -1:
+        epoch = ""
+    else:
+        epoch = filename[:epoch_index]
+
+    name = filename[epoch_index + 1 : ver_index].strip()
+    return name, ver, rel, epoch, arch
+
+
+def discover_cuda_version(interactive: bool = False) -> Optional[str]:
     """Check for CUDA version, if no CUDA is installed, return None."""
-    if bool(int(os.getenv("THAMOS_DISABLE_CUDA", 0))):
+    if bool(int(os.getenv("THAMOS_DISABLE_CUDA", 1))):
         _LOGGER.debug(
             "Disabling CUDA based on THAMOS_DISABLE_CUDA environment variable that is set to %r",
             os.environ["THAMOS_DISABLE_CUDA"],
         )
         return None
+
+    _LOGGER.debug(
+        "Enabling CUDA based on THAMOS_DISABLE_CUDA environment variable that is set to %r",
+        os.environ["THAMOS_DISABLE_CUDA"],
+    )
 
     result = run_command("nvcc --version", raise_on_error=False)
     if result.return_code != 0:
@@ -71,6 +109,83 @@ def discover_cuda_version(interactive: bool = False) -> typing.Optional[str]:
     return cuda_version
 
 
+def discover_cudnn_version() -> Optional[str]:
+    """Discover CuDNN version and return None if not found."""
+    result = run_command("nvcc --version", raise_on_error=False)
+
+    if result.return_code != 0:
+        _LOGGER.debug("No CUDA version detected")
+        _LOGGER.debug(
+            "Unable to detect CUDA version - nvcc returned non-zero version: %s",
+            result.to_dict(),
+        )
+        return None
+
+    for cudnn_header_path in [
+        "/usr/local/cuda/include/cudnn.h",
+        "/usr/include/cudnn.h",
+    ]:
+        cudnn_version_command = run_command(
+            f"cat {cudnn_header_path} | grep CUDNN_MAJOR -A 10", raise_on_error=False
+        )
+
+        if cudnn_version_command.return_code != 0:
+            _LOGGER.debug(
+                f"Unable to locate cudnn.h at {cudnn_header_path.split('/')[-1]}"
+            )
+
+        else:
+            cudnn_version_header = cudnn_version_command.stdout
+            major_version, minor_version, patch_level = [None] * 3
+
+            for line in cudnn_version_header.splitlines():
+                if "CUDNN_MAJOR" in line and major_version is None:
+                    cudnn_major_location = line.rfind("CUDNN_MAJOR") + len(
+                        "CUDNN_MAJOR"
+                    )
+                    major_version = line[cudnn_major_location:].strip()
+
+                if "CUDNN_MINOR" in line and minor_version is None:
+                    cudnn_minor_location = line.rfind("CUDNN_MINOR") + len(
+                        "CUDNN_MINOR"
+                    )
+                    minor_version = line[cudnn_minor_location:].strip()
+
+                if "CUDNN_PATCHLEVEL" in line and patch_level is None:
+                    cudnn_patchlevel_location = line.rfind("CUDNN_PATCHLEVEL") + len(
+                        "CUDNN_PATCHLEVEL"
+                    )
+                    patch_level = line[cudnn_patchlevel_location:].strip()
+
+            if major_version is None:
+                _LOGGER.error(f"No cuDNN major version detected in {cudnn_header_path}")
+                break
+
+            cudnn_version = major_version
+            if minor_version:
+                cudnn_version += f".{minor_version}"
+
+            if patch_level:
+                cudnn_version += f".{patch_level}"
+
+            _LOGGER.debug("Detected cuDNN version %s", cudnn_version)
+            return cudnn_version
+
+    _LOGGER.debug("No cuDNN version detected")
+    return None
+
+
+def discover_mkl_version() -> Optional[str]:
+    """Discover MLK Python package version and return None if not found."""
+    result = run_command("pip list | grep -F mkl", raise_on_error=False)
+
+    if result.return_code != 0:
+        _LOGGER.debug("No MKL Python package detected")
+        return None
+
+    return result.stdout.splitlines()[0].split(" ")[-1]
+
+
 def discover_distribution() -> tuple:
     """Get distribution identifier and distribution version."""
     distribution, version, *_ = distro.linux_distribution(full_distribution_name=False)
@@ -92,7 +207,7 @@ def discover_cpu() -> Dict[str, Union[str, int, None]]:
         "cpu_family": None,
         "cpu_model": None,
         "cpu_model_name": None,
-    }  # type: Dict[str, Union[str, int, None]]
+    }  # type: Dict[str, Any]
 
     try:
         with open(_PROC_CPU_INFO, "r") as cpu_info_file:
@@ -130,9 +245,7 @@ def discover_cpu() -> Dict[str, Union[str, int, None]]:
     except Exception as exc:
         _LOGGER.exception("Failed to obtain CPU specific information: %s", str(exc))
 
-    if result["cpu_model_name"] is None:
-        # Assign a text representation - unknown for config file.
-        result["cpu_model_name"] = "Unknown"
+    result = {k: v or "Unknown" for k, v in result.items()}
 
     _LOGGER.debug(
         "Detected CPU: %s", ", ".join((f"{k}: {v}" for k, v in result.items()))
@@ -147,7 +260,7 @@ def discover_platform() -> str:
     return platform
 
 
-def discover_base_image() -> typing.Optional[str]:
+def discover_base_image() -> Optional[str]:
     """Discover base image and its version."""
     # IMAGE_NAME and IMAGE_TAG injected by AICoE-CI take precedence over Thoth s2i.
     base_image_name = os.getenv("IMAGE_NAME", os.getenv("THOTH_S2I_NAME"))
@@ -175,21 +288,71 @@ def discover_base_image() -> typing.Optional[str]:
     return None
 
 
-def discover_all() -> typing.Dict[str, typing.Any]:
+def discover_rpm_package(package_name: str) -> Optional[Dict[str, str]]:
+    """Check for version of a RPM package and return None if not found."""
+    result = run_command(f"rpm -qa | grep {package_name}", raise_on_error=False)
+
+    if result.return_code != 0:
+        _LOGGER.debug("No %s version detected", package_name)
+        _LOGGER.debug("%s not found in RPM packages", package_name)
+        return None
+
+    if result.stdout is not None:
+        for line in result.stdout.splitlines():
+            name, ver, rel, epoch, arch = _split_rpm_filename(line)
+            if name == package_name:
+                _LOGGER.debug("%s detected with version %s", package_name, ver)
+                return {
+                    "name": name,
+                    "version": ver,
+                    "release": rel,
+                    "epoch": epoch,
+                    "architecture": arch,
+                }
+
+    return None
+
+
+def discover_gpu_model() -> Optional[str]:
+    """Check for GPU model and return None if not found."""
+    result = run_command("lspci | grep VGA", raise_on_error=False)
+
+    if result.return_code != 0:
+        _LOGGER.debug("No GPU model detected")
+        _LOGGER.debug(
+            "Unable to detect GPU model - 'lspci | grep VGA' returned non-zero version: %s",
+            result.to_dict(),
+        )
+        return None
+
+    gpu_model = "VGA" + result.stdout.splitlines()[0].split("VGA")[-1]
+    _LOGGER.debug("GPU model detected: %s", gpu_model)
+
+    return gpu_model
+
+
+def discover_all() -> Dict[str, Any]:
     """Discover all the entries used in Thoth's configuration file."""
-    # XXX: missing autodiscovery for OpenBLAS, OpenMPI, cuDNN, MKL, hardware.gpu_model
     result = {
         "cuda_version": discover_cuda_version(),
+        "cudnn_version": discover_cudnn_version(),
         "python_version": discover_python_version(),
         "platform": discover_platform(),
         "base_image": discover_base_image(),
-        "hardware": discover_cpu(),
+        "openmpi_version": discover_rpm_package("openmpi"),
+        "openblas_version": discover_rpm_package("openblas"),
+        "mkl_version": discover_mkl_version(),
     }
 
     os_name, os_version = discover_distribution()
     result["operating_system"] = {
         "name": os_name,
         "version": os_version,
+    }
+
+    result["hardware"] = {
+        **{k: v or "null" for k, v in discover_cpu().items()},
+        "gpu_model": discover_gpu_model() or "Unknown",
     }
 
     return result

--- a/thamos/discover.py
+++ b/thamos/discover.py
@@ -72,9 +72,9 @@ def _split_rpm_filename(filename):
 def discover_cuda_version(interactive: bool = False) -> Optional[str]:
     """Check for CUDA version, if no CUDA is installed, return None."""
     thamos_disable_cuda = os.getenv("THAMOS_DISABLE_CUDA", None)
-    if thamos_disable_cuda == 1:
+    if thamos_disable_cuda == "1":
         _LOGGER.debug(
-            "Disabling CUDA based on THAMOS_DISABLE_CUDA environment variable that is set to 0",
+            "Disabling CUDA based on THAMOS_DISABLE_CUDA environment variable that is set to 1",
         )
         return None
 

--- a/thamos/discover.py
+++ b/thamos/discover.py
@@ -71,16 +71,15 @@ def _split_rpm_filename(filename):
 
 def discover_cuda_version(interactive: bool = False) -> Optional[str]:
     """Check for CUDA version, if no CUDA is installed, return None."""
-    if bool(int(os.getenv("THAMOS_DISABLE_CUDA", 1))):
+    thamos_disable_cuda = os.getenv("THAMOS_DISABLE_CUDA", None)
+    if thamos_disable_cuda == 1:
         _LOGGER.debug(
-            "Disabling CUDA based on THAMOS_DISABLE_CUDA environment variable that is set to %r",
-            os.environ["THAMOS_DISABLE_CUDA"],
+            "Disabling CUDA based on THAMOS_DISABLE_CUDA environment variable that is set to 0",
         )
         return None
 
     _LOGGER.debug(
-        "Enabling CUDA based on THAMOS_DISABLE_CUDA environment variable that is set to %r",
-        os.environ["THAMOS_DISABLE_CUDA"],
+        "Enabling CUDA based on THAMOS_DISABLE_CUDA environment variable that is set to 0",
     )
 
     result = run_command("nvcc --version", raise_on_error=False)


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes #1127 and #1108 

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Extend the `thamos discover` command with auto-discovery for OpenBLAS, OpenMPI, cuDNN, MKL, hardware.gpu_model and unit tests.
