### PR TITLE
added option to shorten results and reprint advise result table

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -62,6 +62,7 @@ from thamos.lib import load_dot_env
 from thamos.lib import load_files
 from thamos.lib import provenance_check as thoth_provenance_check
 from thamos.lib import print_dependency_graph
+from thamos.lib import print_advise_results
 from thamos.lib import get_verified_packages_from_static_analysis
 from thamos.lib import write_configuration
 from thamos.lib import write_files
@@ -208,6 +209,33 @@ def _print_report(
     console.print(table, justify="center")
 
 
+def _print_report_summary(
+    analysis_id: str,
+    report: list,
+    *,
+    json_output: bool = False,
+):
+    """Print reasoning to user."""
+    if json_output:
+        click.echo(json.dumps(report, sort_keys=True, indent=2))
+        return
+
+    console = Console()
+
+    types = [0, 0, 0]
+    for item in report:
+        if item["type"] == 'INFO':
+            types[0] += 1
+        elif item["type"] == 'WARNING':
+            types[1] += 1
+        elif item["type"] == 'ERROR':
+            types[2] += 1
+
+    console.print(f"Short Summary", justify="center", style="bold")
+    console.print(f"The advise analysis fished with {types[0]} INFO messages, {types[1]} WARNING messages, and {types[2]} ERROR messages.", justify="center")
+    console.print(f"Results can be browsed in Thoth search: [link https://thoth-station.ninja/search/advise/{analysis_id}]https://thoth-station.ninja/search/advise/{analysis_id}", justify="center")
+
+
 def _parse_labels(label: Optional[str]) -> Optional[Dict[str, str]]:
     """Parse labels from their string representation."""
     if not label:
@@ -232,6 +260,28 @@ def _parse_labels(label: Optional[str]) -> Optional[Dict[str, str]]:
         labels[lab[0]] = lab[1]
 
     return labels
+
+
+def _print_advise_justifications(result, json_output: bool = False,):
+    if result["report"] and result["report"]["stack_info"]:
+        _print_report(
+            result["report"]["stack_info"],
+            json_output=json_output,
+            title="Application stack guidance",
+        )
+
+    # Print report of the best one - thus index zero.
+    if result["report"] and result["report"]["products"]:
+        if result["report"]["products"][0]["justification"]:
+            _print_report(
+                result["report"]["products"][0]["justification"],
+                json_output=json_output,
+                title="Recommended stack report",
+            )
+        else:
+            click.echo(
+                "No justification was made for the recommended stack"
+            )
 
 
 class AliasedGroup(click.RichGroup):
@@ -639,6 +689,11 @@ def purge(
     "--json", "-j", "json_output", is_flag=True, help="Print output in JSON format."
 )
 @click.option(
+    "--short",
+    is_flag=True,
+    help="Shorten the analysis output.",
+)
+@click.option(
     "--force",
     is_flag=True,
     envvar="THAMOS_FORCE",
@@ -698,6 +753,7 @@ def advise(
     no_wait: bool = False,
     no_static_analysis: bool = False,
     json_output: bool = False,
+    short: bool = False,
     force: bool = False,
     dev: bool = False,
     no_user_stack: bool = False,
@@ -763,7 +819,7 @@ def advise(
         click.echo(results)
         sys.exit(0)
 
-    result, error = results
+    result, error, metadata = results
     if error:
         if json_output:
             json.dump(result, sys.stdout, indent=2)
@@ -793,25 +849,14 @@ def advise(
                 )
 
             else:
-                if result["report"] and result["report"]["stack_info"]:
-                    _print_report(
+                if short:
+                    _print_report_summary(
+                        metadata.document_id,
                         result["report"]["stack_info"],
                         json_output=json_output,
-                        title="Application stack guidance",
                     )
-
-                # Print report of the best one - thus index zero.
-                if result["report"] and result["report"]["products"]:
-                    if result["report"]["products"][0]["justification"]:
-                        _print_report(
-                            result["report"]["products"][0]["justification"],
-                            json_output=json_output,
-                            title="Recommended stack report",
-                        )
-                    else:
-                        click.echo(
-                            "No justification was made for the recommended stack"
-                        )
+                else:
+                    _print_advise_justifications(result, json_output=json_output)
 
             pipfile = result["report"]["products"][0]["project"]["requirements"]
             pipfile_lock = result["report"]["products"][0]["project"][
@@ -1061,6 +1106,51 @@ def graph(
         printed = print_dependency_graph(analysis_id, fold=fold)
         if not printed:
             sys.exit(1)
+
+
+@cli.command("results")
+@click.pass_context
+@click.argument("analysis_id", type=str, required=False, metavar="ANALYSIS_ID")
+@click.option(
+    "--json", "-j", "json_output", is_flag=True, help="Print output in JSON format."
+)
+@click.option(
+    "--runtime-environment",
+    "-r",
+    default=None,
+    metavar="NAME",
+    envvar="THAMOS_RUNTIME_ENVIRONMENT",
+    help="Specify runtime environment to which the given package should be added.",
+)
+@handle_cli_exception
+def results(
+    analysis_id: typing.Optional[str] = None,
+    runtime_environment: typing.Optional[str] = None,
+    json_output: bool = False,
+) -> None:  # noqa: D412
+    """Show results of finished adviser analysis.
+
+    If ANALYSIS_ID is not provided, the last request is used by default.
+
+    [bold yellow]Examples:[/bold yellow]
+    [purple]
+
+      thamos results
+
+      thamos results adviser-940101080006-110c392feb7cf6da
+    [/purple]
+    """
+    with cwd(configuration.get_overlays_directory(runtime_environment)):
+        result = print_advise_results(analysis_id)
+
+        if json_output:
+            _print_report(
+                result["report"],
+                json_output=json_output,
+            )
+
+        else:
+            _print_advise_justifications(result, json_output=json_output)
 
 
 @cli.command("list")

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -209,12 +209,7 @@ def _print_report(
     console.print(table, justify="center")
 
 
-def _print_report_summary(
-    analysis_id: str,
-    report: list,
-    *,
-    json_output: bool = False,
-):
+def _print_report_summary(analysis_id: str, report: list, *, json_output: bool = False):
     """Print reasoning to user."""
     if json_output:
         click.echo(json.dumps(report, sort_keys=True, indent=2))
@@ -222,18 +217,21 @@ def _print_report_summary(
 
     console = Console()
 
-    types = [0, 0, 0]
+    types = {"INFO": 0, "WARNING": 0, "ERROR": 0}
     for item in report:
-        if item["type"] == 'INFO':
-            types[0] += 1
-        elif item["type"] == 'WARNING':
-            types[1] += 1
-        elif item["type"] == 'ERROR':
-            types[2] += 1
+        types[item["type"]] += 1
 
-    console.print(f"Short Summary", justify="center", style="bold")
-    console.print(f"The advise analysis fished with {types[0]} INFO messages, {types[1]} WARNING messages, and {types[2]} ERROR messages.", justify="center")
-    console.print(f"Results can be browsed in Thoth search: [link https://thoth-station.ninja/search/advise/{analysis_id}]https://thoth-station.ninja/search/advise/{analysis_id}", justify="center")
+    console.print("Short Summary", justify="center", style="bold")
+    console.print(
+        f"The advise analysis fished with {types['INFO']} INFO messages, {types['WARNING']} WARNING messages,"
+        + f" and {types['ERROR']} ERROR messages.",
+        justify="center",
+    )
+    console.print(
+        "Results can be browsed in Thoth search: [link https://thoth-station.ninja/search/advise/"
+        + f"{analysis_id}]https://thoth-station.ninja/search/advise/{analysis_id}",
+        justify="center",
+    )
 
 
 def _parse_labels(label: Optional[str]) -> Optional[Dict[str, str]]:
@@ -262,7 +260,10 @@ def _parse_labels(label: Optional[str]) -> Optional[Dict[str, str]]:
     return labels
 
 
-def _print_advise_justifications(result, json_output: bool = False,):
+def _print_advise_justifications(
+    result,
+    json_output: bool = False,
+):
     if result["report"] and result["report"]["stack_info"]:
         _print_report(
             result["report"]["stack_info"],
@@ -279,9 +280,7 @@ def _print_advise_justifications(result, json_output: bool = False,):
                 title="Recommended stack report",
             )
         else:
-            click.echo(
-                "No justification was made for the recommended stack"
-            )
+            click.echo("No justification was made for the recommended stack")
 
 
 class AliasedGroup(click.RichGroup):
@@ -1120,7 +1119,7 @@ def graph(
     default=None,
     metavar="NAME",
     envvar="THAMOS_RUNTIME_ENVIRONMENT",
-    help="Specify runtime environment to which the given package should be added.",
+    help="Specify runtime environment used to retrieve analysis results.",
 )
 @handle_cli_exception
 def results(
@@ -1143,14 +1142,7 @@ def results(
     with cwd(configuration.get_overlays_directory(runtime_environment)):
         result = print_advise_results(analysis_id)
 
-        if json_output:
-            _print_report(
-                result["report"],
-                json_output=json_output,
-            )
-
-        else:
-            _print_advise_justifications(result, json_output=json_output)
+        _print_advise_justifications(result, json_output=json_output)
 
 
 @cli.command("list")

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -32,6 +32,8 @@ from functools import partial
 from functools import wraps
 import pprint
 import json
+
+import click
 import urllib3
 import requests
 
@@ -587,7 +589,7 @@ def advise(
         return None
 
     _LOGGER.debug("Adviser check metadata: %r", response.metadata)
-    return response.result.to_dict(), response.result.error
+    return response.result.to_dict(), response.result.error, response.metadata
 
 
 def advise_here(
@@ -1627,6 +1629,27 @@ def print_dependency_graph(
         return False
 
     return print_dependency_graph_from_adviser_document(adviser_document, fold=fold)
+
+
+def print_advise_results(
+    analysis_id: typing.Optional[str] = None
+) -> AnalysisResultResponse.result:
+    """Print dependency graph to stdout produced by the given adviser."""
+    analysis_id = analysis_id or get_last_analysis_id()
+    if not analysis_id.startswith("adviser-"):
+        raise UnknownAnalysisType(
+            f"An adviser identifier is required to print a analysis results, got {analysis_id!r} instead"
+        )
+
+    adviser_document, error = get_analysis_results(analysis_id)
+
+    if error:
+        print("Cannot print dependency graph as advise was not successful")
+
+    if not adviser_document:
+        sys.exit(2)
+
+    return adviser_document
 
 
 def add_requirements_to_project(

--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -33,7 +33,6 @@ from functools import wraps
 import pprint
 import json
 
-import click
 import urllib3
 import requests
 
@@ -1631,9 +1630,7 @@ def print_dependency_graph(
     return print_dependency_graph_from_adviser_document(adviser_document, fold=fold)
 
 
-def print_advise_results(
-    analysis_id: typing.Optional[str] = None
-) -> AnalysisResultResponse.result:
+def print_advise_results(analysis_id: typing.Optional[str] = None):
     """Print dependency graph to stdout produced by the given adviser."""
     analysis_id = analysis_id or get_last_analysis_id()
     if not analysis_id.startswith("adviser-"):
@@ -1644,7 +1641,7 @@ def print_advise_results(
     adviser_document, error = get_analysis_results(analysis_id)
 
     if error:
-        print("Cannot print dependency graph as advise was not successful")
+        print("Cannot print analysis results as advise was not successful")
 
     if not adviser_document:
         sys.exit(2)


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

fixes: https://github.com/thoth-station/thamos/issues/1118

## This introduces a breaking change
<!-- Leave one of the options -->
- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

This PR adds a new option for `thamos advise` named `--short`. This tag shortens the resulting output of an advise to only show the link to the Thoth Search page and a cumulative summary of the justification types.
```
Short Summary                                                                                                                                                      
The advise analysis fished with 19 INFO messages, 78 WARNING messages, and 0 ERROR messages.                                                                                                              
Results can be browsed in Thoth search: https://thoth-station.ninja/search/advise/adviser-220711195405-198a77724b0a055 
```

This PR also adds a new Thamos command: `thamos results {analysis_id}`. This command returns the table output of an advise run. Optionally you can provide a different _analysis_id_ instead of using the last run analysis_id.

### Description
<!--- Describe your changes in detail here. -->
I also condensed printing the table code into one function as multiple options use it now.
