### PR TITLE
Ignore `.venv` content when getting static analysis of files

### DIFF
--- a/thamos/lib.py
+++ b/thamos/lib.py
@@ -319,6 +319,7 @@ def get_static_analysis(
         library_usage = gather_library_usage(
             src_path,
             ignore_errors=True,
+            ignored_subdirs=[".venv"],
             without_standard_imports=without_standard_imports,
             without_builtin_imports=without_builtin_imports,
             without_builtins=without_builtins,


### PR DESCRIPTION
## Related Issues and Dependencies
Depends on https://github.com/thoth-station/invectio/pull/148
Fixes https://github.com/thoth-station/thamos/issues/1123

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Allow scanning content of `.venv` when gathering library usage with `invectio`.
