### PR TITLE
Update defaultThoth.yaml

### DIFF
--- a/thamos/data/defaultThoth.yaml
+++ b/thamos/data/defaultThoth.yaml
@@ -11,7 +11,8 @@ tls_verify: true
 # Format of requirements file, supported are "pip" and "pipenv":
 requirements_format: {requirements_format}
 # A path to overlays directory relative to this configuration file. If null provided, no overlays are used.
-overlays_dir: overlays
+# Read more about overlays in the README: https://github.com/thoth-station/thamos#overlays-directory
+overlays_dir: null
 # Allow or disable managing virtual environment for each overlay.
 virtualenv: false
 


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

n/a

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->
Set ehe default value of the overlays directory to `null

### Description
<!--- Describe your changes in detail here. -->
`thamos config` uses the default `.thoth.yaml` but this file sets the overlays directly by default. But it does not create an overlays directly. SO the default `.thoth.yaml` will error out unless that is addressed.
