### PR TITLE
filter option to results

### DIFF
--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1339,6 +1339,7 @@ def graph(
 )
 @handle_cli_exception
 def results(
+    *,
     analysis_id: typing.Optional[str] = None,
     runtime_environment: typing.Optional[str] = None,
     json_output: bool = False,

--- a/thamos/cli.py
+++ b/thamos/cli.py
@@ -1339,7 +1339,6 @@ def graph(
 )
 @handle_cli_exception
 def results(
-    *,
     analysis_id: typing.Optional[str] = None,
     runtime_environment: typing.Optional[str] = None,
     json_output: bool = False,


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->
fixes: https://github.com/thoth-station/thamos/issues/1129

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- Yes

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

Adds new options to `thamos result`
- `thamos result --filter type=INFO`
- `thamos result --list-categories`

### Description
<!--- Describe your changes in detail here. -->

- `filter` allows you to apply a regex matching pattern to any of the keys in the justifications
- `list-categories` aggregates the types and prints the totals. When tags are added this will also be displayed